### PR TITLE
File watcher

### DIFF
--- a/coconut/command.py
+++ b/coconut/command.py
@@ -614,30 +614,8 @@ class cli(object):
 
     def watch(self, source, write=True, package=None, run=False, force=False):
         """Watches a file, and recompiles on change"""
-        if os.path.isfile(source):
-            lastTime = 0
-            while True:
-                newTime = os.stat(source).st_mtime
-                #If the file has changed
-                if lastTime != newTime:
-                    lastTime = newTime
-                    #Recompile it
-                    self.compile_path(source,write,package,run,force)
+        #self.compile_path(source,write,package,run,force)
+        from .watch import realWatch
+        realWatch(self,source,write,package,run,force)
 
-                time.sleep(1)
-        else:
-            lastTimes = []
-            while True:
-                newTimes = []
-                for path, subdirs, files in os.walk(source):
-                    for name in files:
-                        fullPath = os.path.join(path,name)
-                        ext = os.path.splitext(fullPath)[-1]
-                        if ext in code_exts:
-                            newTime = os.stat(fullPath).st_mtime
-                            newTimes.append(newTime)
-                if set(lastTimes) != set(newTimes):
-                    lastTimes = newTimes
-                    self.compile_path(source,write,package,run,force)
-
-            time.sleep(1)
+        

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -318,7 +318,7 @@ class cli(object):
                 self.proc.debug(True)
             if args.autopep8 is not None:
                 self.proc.autopep8(args.autopep8)
-            if args.source is not None and not args.watch:
+            if args.source is not None:
                 if args.run and os.path.isdir(args.source):
                     raise CoconutException("source path must point to file not directory when --run is enabled")
                 if args.dest is None:
@@ -340,6 +340,9 @@ class cli(object):
                     package = False
                 else:
                     package = None # auto-decide package
+
+                if args.watch:
+                    self.watch(args.source,dest,package,args.run,args.force)
                 self.compile_path(args.source, dest, package, args.run, args.force)
             elif args.run or args.nowrite or args.force or args.package or args.standalone:
                 raise CoconutException("a source file/folder must be specified when options that depend on the source are enabled")
@@ -350,8 +353,6 @@ class cli(object):
                 self.execute(self.proc.parse_block(sys.stdin.read()))
             if args.jupyter is not None:
                 self.start_jupyter(args.jupyter)
-            if args.watch:
-                self.watch(args.source)
             if args.interact or (interact and not (
                     stdin
                     or args.source
@@ -611,7 +612,7 @@ class cli(object):
             self.log_cmd(run_args)
             subprocess.call(run_args)
 
-    def watch(self,source):
+    def watch(self, source, write=True, package=None, run=False, force=False):
         """Watches a file, and recompiles on change"""
         if os.path.isfile(source):
             lastTime = 0
@@ -621,7 +622,7 @@ class cli(object):
                 if lastTime != newTime:
                     lastTime = newTime
                     #Recompile it
-                    self.compile_path(source)
+                    self.compile_path(source,write,package,run,force)
 
                 time.sleep(1)
         else:
@@ -635,6 +636,6 @@ class cli(object):
                         newTimes.append(newTime)
                 if set(lastTimes) != set(newTimes):
                     lastTimes = newTimes
-                    self.compile_path(source)
+                    self.compile_path(source,write,package,run,force)
 
             time.sleep(1)

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -612,11 +612,24 @@ class cli(object):
 
     def watch(self,source):
         """Watches a file, and recompiles on change"""
-        lastTime = 0
-        while True:
-            newTime = os.stat(source).st_mtime
-            #If the file has changed
-            if lastTime != newTime:
-                lastTime = newTime
-                #Recompile it
-                self.compile_path(source)
+        if os.path.isfile(source):
+            lastTime = 0
+            while True:
+                newTime = os.stat(source).st_mtime
+                #If the file has changed
+                if lastTime != newTime:
+                    lastTime = newTime
+                    #Recompile it
+                    self.compile_path(source)
+        else:
+            lastTimes = []
+            while True:
+                newTimes = []
+                for path, subdirs, files in os.walk(source):
+                    for name in files:
+                        fullPath = os.path.join(path,name)
+                        newTime = os.stat(fullPath).st_mtime
+                        newTimes.append(newTime)
+                if set(lastTimes) != set(newTimes):
+                    lastTimes = newTimes
+                    self.compile_path(source)

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -259,7 +259,7 @@ class cli(object):
     commandline.add_argument("--recursionlimit", metavar="limit", type=int, nargs=1, default=[None], help="set maximum recursion depth (defaults to "+str(sys.getrecursionlimit())+")")
     commandline.add_argument("--tutorial", action="store_const", const=True, default=False, help="open the Coconut tutorial in the default web browser")
     commandline.add_argument("--documentation", action="store_const", const=True, default=False, help="open the Coconut documentation in the default web browser")
-    commandline.add_argument("--watch", action="store_const", const=True, default=False, help="Watch file for changes, and compile when they happen")
+    commandline.add_argument("--watch", action="store_const", const=True, default=False, help="Watch a directory for changes, and compile when they happen")
     commandline.add_argument("--color", metavar="color", type=str, nargs=1, default=[None], help="show all Coconut messages in the given color")
     commandline.add_argument("--verbose", action="store_const", const=True, default=False, help="print verbose debug output")
     proc = None # current .compiler.processor

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -632,8 +632,10 @@ class cli(object):
                 for path, subdirs, files in os.walk(source):
                     for name in files:
                         fullPath = os.path.join(path,name)
-                        newTime = os.stat(fullPath).st_mtime
-                        newTimes.append(newTime)
+                        ext = os.path.splitext(fullPath)[-1]
+                        if ext in code_exts:
+                            newTime = os.stat(fullPath).st_mtime
+                            newTimes.append(newTime)
                 if set(lastTimes) != set(newTimes):
                     lastTimes = newTimes
                     self.compile_path(source,write,package,run,force)

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -611,10 +611,12 @@ class cli(object):
             subprocess.call(run_args)
 
     def watch(self,source):
-        #make this less infanat
+        """Watches a file, and recompiles on change"""
         lastTime = 0
         while True:
             newTime = os.stat(source).st_mtime
+            #If the file has changed
             if lastTime != newTime:
                 lastTime = newTime
+                #Recompile it
                 self.compile_path(source)

--- a/coconut/command.py
+++ b/coconut/command.py
@@ -18,6 +18,7 @@ from __future__ import print_function, absolute_import, unicode_literals, divisi
 
 from .compiler import *
 import os
+import time
 import os.path
 import argparse
 
@@ -621,6 +622,8 @@ class cli(object):
                     lastTime = newTime
                     #Recompile it
                     self.compile_path(source)
+
+                time.sleep(1)
         else:
             lastTimes = []
             while True:
@@ -633,3 +636,5 @@ class cli(object):
                 if set(lastTimes) != set(newTimes):
                     lastTimes = newTimes
                     self.compile_path(source)
+
+            time.sleep(1)

--- a/coconut/watch.py
+++ b/coconut/watch.py
@@ -1,0 +1,34 @@
+import time
+import sys
+import os
+from .command import code_exts
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+class CompilerHandler(FileSystemEventHandler):
+
+    def __init__(self,cli,write, package, run, force):
+        self.cli = cli
+        self.write = write
+        self.package = package
+        self.run = run
+        self.force = force
+
+    def on_modified(self,event):
+        path = event.src_path
+        filename,extention = os.path.splitext(path)
+        if extention in code_exts:
+            self.cli.compile_path(path,self.write,self.package,self.run,self.force)
+
+def realWatch(cli,source, write, package, run, force):
+    event_handler = CompilerHandler(cli,write,package,run,force)
+    observer = Observer()
+    observer.schedule(event_handler,source,recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+    sys.exit(0)


### PR DESCRIPTION
Added file and directory watching flag. This is as requested in issue #99.
Usage:
```
coconut --watch examples/example.coco
coconut --watch examples
```

I did not use the watchdogs library because I wanted to keep dependencies minimal.