### PR TITLE
Zero-Argument addpattern

### DIFF
--- a/coconut/compiler.py
+++ b/coconut/compiler.py
@@ -692,9 +692,13 @@ def addpattern(base_func=None):
                 return func(*args, **kwargs)
         return add_pattern_func
     return pattern_adder
-def prepattern(base_func):
+def prepattern(base_func=None):
     """Decorator to add a new case to a pattern-matching function, where the new case is checked first."""
+    params = {"base_func":base_func}    #More random dictionary stuff
     def pattern_prepender(func):
+        base_func = params["base_func"]
+        if not base_func:
+            base_func = globals()[func.__name__]
         @_coconut.functools.wraps(func)
         def pre_pattern_func(*args, **kwargs):
             try:

--- a/coconut/compiler.py
+++ b/coconut/compiler.py
@@ -677,9 +677,13 @@ def recursive_iterator(func):
         tee_store[hashable_args_kwargs], to_return = _coconut_tee(to_tee)
         return to_return
     return recursive_iterator_func
-def addpattern(base_func):
+def addpattern(base_func=None):
     """Decorator to add a new case to a pattern-matching function, where the new case is checked last."""
+    params = {"base_func":base_func}    #WE HAVE TO USE A DICTIONARY BECAUSE RESONS (https://stackoverflow.com/questions/3190706/nonlocal-keyword-in-python-2-x) (https://stackoverflow.com/questions/18864041/why-can-functions-in-python-print-variables-in-enclosing-scope-but-cannot-use-th)
     def pattern_adder(func):
+        base_func = params["base_func"]
+        if not base_func:
+            base_func = globals()[func.__name__]
         @_coconut.functools.wraps(func)
         def add_pattern_func(*args, **kwargs):
             try:


### PR DESCRIPTION
As seen in #125.

Here is my implementation of a Zero-Argument `addpattern` and `prepattern`. It may be a bad idea to include this in coconut, but I want to put the code here so people can look at it and we can make that call.
Usage:
```python
def factorial(n is int if n > 0):
    """Compute n! where n is an integer >= 0."""
    return range(1, n+1) |> reduce$((*))
    
@prepattern()
def factorial(0):
    return 1

0 |> factorial |> print # 1
3 |> factorial |> print # 6
```