### PR TITLE
Add parens around function composition example.

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1106,7 +1106,7 @@ zipsum = map$(sum)..zip
 
 Function composition also gets rid of the need for lots of parentheses when chaining function calls, like so:
 ```coconut
-plus1..square(3) == 10
+(plus1..square)(3) == 10
 ```
 
 ### Implicit Partials


### PR DESCRIPTION
`plus1..square(3) == 10` currently returns False in the version on pip.