### PR TITLE
Added documentation hint on parentheses around multi-line pipe operators

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -413,6 +413,15 @@ Coconut uses pipe operators for pipeline-style function application. All the ope
 
 Additionally, all pipe operators support a lambda as the last argument, despite lambdas having a lower precedence. Thus, `10 |> x -> x**2` is valid, though the body of the lambda will still capture all following pipe operators.
 
+To visually spread operations using the pipe operators over several lines of code, it is necessary to wrap the entire chain in parentheses:
+```coconut
+(range(10)
+    |> filter$((x) -> (x % 2) == 1)
+    |> map$((x) -> 3 * x)
+    |> list
+    )
+```
+
 ##### Optimizations
 
 It is common in Coconut to write code that uses pipes to pass an object through a series of [partials](#partial-application) and/or [implicit partials](#implicit-partial-application), as in


### PR DESCRIPTION
As per issue #315 I added a hint to the documentation.