### PR TITLE
Fixing typo in the "Optional Dependencies" section

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -51,7 +51,7 @@ pip install coconut[name_of_optional_dependency]
 ```
 or, to install multiple optional dependencies,
 ```
-pip install coocnut[opt_dep_1,opt_dep_2]
+pip install coconut[opt_dep_1,opt_dep_2]
 ```
 
 The full list of optional dependencies is:


### PR DESCRIPTION
Changed "pip install coocnut[...]" to "pip install coconut[...]"

I wasn't sure if opening a PR was the best way to suggest this fix, given how minor it is, so feel free to close the PR if it was not.