### PR TITLE
Fix parser maybeparens

### DIFF
--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -150,7 +150,7 @@ def condense(item):
 
 def maybeparens(lparen, item, rparen):
     """Wrap an item in optional parentheses."""
-    return lparen.suppress() + item + rparen.suppress() | item
+    return item | lparen.suppress() + item + rparen.suppress()
 
 
 def tokenlist(item, sep, suppress=True):

--- a/tests/src/cocotest/agnostic/suite.coco
+++ b/tests/src/cocotest/agnostic/suite.coco
@@ -401,6 +401,8 @@ def suite_test():
     ):
         assert one == 1
         assert two == 2
+    with (context_produces(1)) as one:
+        assert one == 1
     assert 1 ?? raise_exc() == 1
     try:
         assert None ?? raise_exc()


### PR DESCRIPTION
Try to match the might-be-parenthesised item first before trying to
match the parenthesised form.  This allows the first element within the
item to also be parenthesised.

Fixes: #359