### PR TITLE
Use a computation graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ ENV/
 tests/dest/
 docs/
 index.rst
+profile.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ prune docs
 prune .mypy_cache
 prune *.egg-info
 exclude index.rst
+exclude profile.json

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ check:
 
 .PHONY: profile
 profile:
-	vprof -c pmh "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
+	vprof -c mh "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
 
 .PHONY: view-profile
 view-profile:

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ profile-code:
 
 .PHONY: profile-memory
 profile-memory:
-	vprof -m h "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
+	vprof -c m "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
 
 .PHONY: view-profile
 view-profile:

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,13 @@ upload: build
 check:
 	python ./coconut/requirements.py
 
-.PHONY: profile
-profile:
-	vprof -c mh "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
+.PHONY: profile-code
+profile-code:
+	vprof -c h "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
+
+.PHONY: profile-memory
+profile-memory:
+	vprof -m h "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
 
 .PHONY: view-profile
 view-profile:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docs: clean
 
 .PHONY: clean
 clean:
-	rm -rf ./docs ./dist ./build ./tests/dest index.rst
+	rm -rf ./docs ./dist ./build ./tests/dest index.rst profile.json
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
 
@@ -66,3 +66,11 @@ upload: build
 .PHONY: check
 check:
 	python ./coconut/requirements.py
+
+.PHONY: profile
+profile:
+	vprof -c pmh "coconut tests/src/cocotest/agnostic tests/dest/cocotest --force" --output-file ./profile.json
+
+.PHONY: view-profile
+view-profile:
+	vprof --input-file ./profile.json

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -372,6 +372,7 @@ class Compiler(Grammar):
     def bind(self):
         """Binds reference objects to the proper parse actions."""
         self.endline <<= attach(self.endline_ref, self.endline_handle)
+        # comments are evaluated greedily because we need to know about them even if we're going to suppress them
         self.comment <<= trace(attach(self.comment_ref, self.comment_handle, greedy=True))
         self.moduledoc_item <<= trace(attach(self.moduledoc, self.set_docstring))
         self.name <<= trace(attach(self.base_name, self.name_check))

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -414,12 +414,12 @@ class Compiler(Grammar):
 
     def adjust(self, ln):
         """Adjusts a line number."""
-        adj_ln = 0
-        i = 0
-        while i < ln:
+        adj_ln = ln
+        need_unskipped = sum(1 for i in self.skips if i <= ln)
+        while need_unskipped:
             adj_ln += 1
             if adj_ln not in self.skips:
-                i += 1
+                need_unskipped -= 1
         return adj_ln
 
     def reformat(self, snip, index=None):

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -372,7 +372,7 @@ class Compiler(Grammar):
     def bind(self):
         """Binds reference objects to the proper parse actions."""
         self.endline <<= attach(self.endline_ref, self.endline_handle)
-        self.comment <<= attach(self.comment_ref, self.comment_handle)
+        self.comment <<= trace(attach(self.comment_ref, self.comment_handle, greedy=True))
         self.moduledoc_item <<= trace(attach(self.moduledoc, self.set_docstring))
         self.name <<= trace(attach(self.base_name, self.name_check))
 

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -124,9 +124,9 @@ from coconut.compiler.header import (
 def set_to_tuple(tokens):
     """Converts set literal tokens to tuples."""
     internal_assert(len(tokens) == 1, "invalid set maker tokens", tokens)
-    if "comp" in tokens.keys() or "list" in tokens.keys():
+    if "comp" in tokens or "list" in tokens:
         return "(" + tokens[0] + ")"
-    elif "test" in tokens.keys():
+    elif "test" in tokens:
         return "(" + tokens[0] + ",)"
     else:
         raise CoconutInternalException("invalid set maker item", tokens[0])
@@ -1163,11 +1163,11 @@ class Compiler(Grammar):
             else:
                 return "(_coconut.object)"
         elif len(tokens) == 1 and len(tokens[0]) == 1:
-            if "tests" in tokens[0].keys():
+            if "tests" in tokens[0]:
                 if self.strict and tokens[0][0] == "(object)":
                     raise self.make_err(CoconutStyleError, "unnecessary inheriting from object (Coconut does this automatically)", original, loc)
                 return tokens[0][0]
-            elif "args" in tokens[0].keys():
+            elif "args" in tokens[0]:
                 if self.target.startswith("3"):
                     return tokens[0][0]
                 else:
@@ -1196,19 +1196,19 @@ class Compiler(Grammar):
         for i, arg in enumerate(original_args):
 
             star, default, typedef = False, None, None
-            if "name" in arg.keys():
+            if "name" in arg:
                 internal_assert(len(arg) == 1)
                 argname = arg[0]
-            elif "default" in arg.keys():
+            elif "default" in arg:
                 internal_assert(len(arg) == 2)
                 argname, default = arg
-            elif "star" in arg.keys():
+            elif "star" in arg:
                 internal_assert(len(arg) == 1)
                 star, argname = True, arg[0]
-            elif "type" in arg.keys():
+            elif "type" in arg:
                 internal_assert(len(arg) == 2)
                 argname, typedef = arg
-            elif "type default" in arg.keys():
+            elif "type default" in arg:
                 internal_assert(len(arg) == 3)
                 argname, typedef, default = arg
             else:
@@ -1325,18 +1325,18 @@ class Compiler(Grammar):
             ) + "):\n" + openindent
         )
         rest = None
-        if "simple" in stmts.keys() and len(stmts) == 1:
+        if "simple" in stmts and len(stmts) == 1:
             out += extra_stmts
             rest = stmts[0]
-        elif "docstring" in stmts.keys() and len(stmts) == 1:
+        elif "docstring" in stmts and len(stmts) == 1:
             out += stmts[0] + extra_stmts
-        elif "complex" in stmts.keys() and len(stmts) == 1:
+        elif "complex" in stmts and len(stmts) == 1:
             out += extra_stmts
             rest = "".join(stmts[0])
-        elif "complex" in stmts.keys() and len(stmts) == 2:
+        elif "complex" in stmts and len(stmts) == 2:
             out += stmts[0] + extra_stmts
             rest = "".join(stmts[1])
-        elif "empty" in stmts.keys() and len(stmts) == 1:
+        elif "empty" in stmts and len(stmts) == 1:
             out += extra_stmts.rstrip() + stmts[0]
         else:
             raise CoconutInternalException("invalid inner data tokens", stmts)
@@ -1501,7 +1501,7 @@ class Compiler(Grammar):
             params, stmts = tokens
         elif len(tokens) == 3:
             params, stmts, last = tokens
-            if "tests" in tokens.keys():
+            if "tests" in tokens:
                 stmts = stmts.asList() + ["return " + last]
             else:
                 stmts = stmts.asList() + [last]

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -414,7 +414,13 @@ class Compiler(Grammar):
 
     def adjust(self, ln):
         """Adjusts a line number."""
-        return ln - sum(i < ln for i in self.skips)
+        adj_ln = 0
+        i = 0
+        while i < ln:
+            adj_ln += 1
+            if adj_ln not in self.skips:
+                i += 1
+        return adj_ln
 
     def reformat(self, snip, index=None):
         """Post process a preprocessed snippet."""

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -414,13 +414,7 @@ class Compiler(Grammar):
 
     def adjust(self, ln):
         """Adjusts a line number."""
-        adj_ln = 0
-        i = 0
-        while i < ln:
-            adj_ln += 1
-            if adj_ln not in self.skips:
-                i += 1
-        return adj_ln
+        return ln - sum(i < ln for i in self.skips)
 
     def reformat(self, snip, index=None):
         """Post process a preprocessed snippet."""
@@ -520,7 +514,7 @@ class Compiler(Grammar):
         """Perform pre-processing."""
         out = self.apply_procs(self.preprocs, kwargs, str(inputstring))
         if self.line_numbers or self.keep_lines:
-            logger.log_tag("skips", list(sorted(self.skips)))
+            logger.log_tag("skips", lambda: list(sorted(self.skips)))
         return out
 
     def post(self, result, **kwargs):

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -522,10 +522,10 @@ class Compiler(Grammar):
             logger.log_tag("skips", list(sorted(self.skips)))
         return out
 
-    def post(self, tokens, **kwargs):
+    def post(self, result, **kwargs):
         """Perform post-processing."""
-        internal_assert(len(tokens) == 1, "multiple tokens leftover", tokens)
-        return self.apply_procs(self.postprocs, kwargs, tokens[0])
+        internal_assert(isinstance(result, str), "got non-string parse result", result)
+        return self.apply_procs(self.postprocs, kwargs, result)
 
     def getheader(self, which, use_hash=None, polish=True):
         """Get a formatted header."""

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -529,7 +529,7 @@ class Compiler(Grammar):
         """Perform pre-processing."""
         out = self.apply_procs(self.preprocs, kwargs, str(inputstring))
         if self.line_numbers or self.keep_lines:
-            logger.log_tag("skips", self.sorted_skips)
+            logger.log_tag("skips", lambda: self.sorted_skips)
         return out
 
     def post(self, result, **kwargs):
@@ -627,7 +627,7 @@ class Compiler(Grammar):
         _contents = 0  # the contents of the string so far
         _start = 1  # the string of characters that started the string
         _stop = 2  # store of characters that might be the end of the string
-        skips = self.skips.copy()
+        skips = self.skips[:]
 
         x = 0
         while x <= len(inputstring):
@@ -727,7 +727,7 @@ class Compiler(Grammar):
         hold = None  # the contents of the passthrough so far
         count = None  # current parenthetical level (num closes - num opens)
         multiline = None  # if in a passthrough, is it a multiline passthrough
-        skips = self.skips.copy()
+        skips = self.skips[:]
 
         for x in range(len(inputstring) + 1):
             if x == len(inputstring):
@@ -796,7 +796,7 @@ class Compiler(Grammar):
         opens = []  # (line, col, adjusted ln) at which open parens were seen, newest first
         current = None  # indentation level of previous line
         levels = []  # indentation levels of all previous blocks, newest at end
-        skips = self.skips.copy()
+        skips = self.skips[:]
 
         for ln in range(1, len(lines) + 1):  # ln is 1-indexed
             line = lines[ln - 1]  # lines is 0-indexed

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -420,6 +420,7 @@ class Compiler(Grammar):
     def set_skips(self, skips):
         """Set the line skips."""
         skips.sort()
+        internal_assert(lambda: len(set(skips)) == len(skips), "duplicate line skip(s) in skips", skips)
         self.skips = skips
 
     def adjust(self, ln):

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -85,6 +85,7 @@ from coconut.compiler.util import (
     join_args,
     disable_inside,
     disable_outside,
+    final,
 )
 
 # end: IMPORTS
@@ -1661,7 +1662,7 @@ class Grammar(object):
     simple_suite = attach(simple_stmt, make_suite_handle)
     nocolon_suite <<= trace(base_suite | simple_suite)
     suite <<= condense(colon + nocolon_suite)
-    line = trace(newline | stmt)
+    line = trace(final(newline | stmt))
 
     single_input = trace(condense(Optional(line) - ZeroOrMore(newline)))
     file_input = trace(condense(moduledoc_marker - ZeroOrMore(line)))

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -1662,6 +1662,7 @@ class Grammar(object):
     simple_suite = attach(simple_stmt, make_suite_handle)
     nocolon_suite <<= trace(base_suite | simple_suite)
     suite <<= condense(colon + nocolon_suite)
+
     line = trace(final(newline | stmt))
 
     single_input = trace(condense(Optional(line) - ZeroOrMore(newline)))

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -143,17 +143,17 @@ def pipe_item_split(tokens, loc):
         - (name, args) for attr/method, and
         - (op, args) for itemgetter."""
     # list implies artificial tokens, which must be expr
-    if isinstance(tokens, list) or "expr" in tokens.keys():
+    if isinstance(tokens, list) or "expr" in tokens:
         internal_assert(len(tokens) == 1, "invalid expr pipe item tokens", tokens)
         return "expr", (tokens[0],)
-    elif "partial" in tokens.keys():
+    elif "partial" in tokens:
         func, args = tokens
         pos_args, star_args, kwd_args, dubstar_args = split_function_call(args, loc)
         return "partial", (func, join_args(pos_args, star_args), join_args(kwd_args, dubstar_args))
-    elif "attrgetter" in tokens.keys():
+    elif "attrgetter" in tokens:
         name, args = attrgetter_atom_split(tokens)
         return "attrgetter", (name, args)
-    elif "itemgetter" in tokens.keys():
+    elif "itemgetter" in tokens:
         op, args = tokens
         return "itemgetter", (op, args)
     else:
@@ -511,9 +511,9 @@ def decorator_handle(tokens):
     defs = []
     decorates = []
     for i, tok in enumerate(tokens):
-        if "simple" in tok.keys() and len(tok) == 1:
+        if "simple" in tok and len(tok) == 1:
             decorates.append("@" + tok[0])
-        elif "test" in tok.keys() and len(tok) == 1:
+        elif "test" in tok and len(tok) == 1:
             varname = decorator_var + "_" + str(i)
             defs.append(varname + " = " + tok[0])
             decorates.append("@" + varname)
@@ -596,7 +596,7 @@ def except_handle(tokens):
     else:
         raise CoconutInternalException("invalid except tokens", tokens)
     out = "except "
-    if "list" in tokens.keys():
+    if "list" in tokens:
         out += "(" + errs + ")"
     else:
         out += errs
@@ -1688,6 +1688,7 @@ class Grammar(object):
             + ZeroOrMore(dot + base_name | brackets | parens + ~end_marker),
         ) + parens + end_marker,
         tco_return_handle,
+        greedy=True,
     )
 
     rest_of_arg = ZeroOrMore(parens | brackets | braces | ~comma + ~rparen + any_char)
@@ -1706,6 +1707,7 @@ class Grammar(object):
         (start_marker - Keyword("def")).suppress() - dotted_base_name - lparen.suppress()
         - parameters_tokens - rparen.suppress(),
         split_func_name_args_params_handle,
+        greedy=True,
     )
 
     stores_scope = (
@@ -1731,5 +1733,6 @@ def set_grammar_names():
 
 if DEVELOP:
     set_grammar_names()
+
 
 # end: NAMING

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -293,6 +293,9 @@ def item_handle(loc, tokens):
     return out
 
 
+item_handle.simple = True
+
+
 def pipe_handle(loc, tokens, **kwargs):
     """Process pipe calls."""
     internal_assert(set(kwargs) <= set(("top",)), "unknown pipe_handle keyword arguments", kwargs)
@@ -401,6 +404,9 @@ def none_coalesce_handle(tokens):
         )
 
 
+none_coalesce_handle.simple = True
+
+
 def attrgetter_atom_handle(loc, tokens):
     """Process attrgetter literals."""
     name, args = attrgetter_atom_split(tokens)
@@ -431,6 +437,9 @@ def chain_handle(tokens):
         return tokens[0]
     else:
         return "_coconut.itertools.chain.from_iterable(" + lazy_list_handle(tokens) + ")"
+
+
+chain_handle.simple = True
 
 
 def infix_handle(tokens):
@@ -637,6 +646,9 @@ def namelist_handle(tokens):
         raise CoconutInternalException("invalid in-line nonlocal / global tokens", tokens)
 
 
+namelist_handle.simple = True
+
+
 def compose_item_handle(tokens):
     """Process function composition."""
     if len(tokens) < 1:
@@ -645,6 +657,9 @@ def compose_item_handle(tokens):
         return tokens[0]
     else:
         return "_coconut_forward_compose(" + ", ".join(reversed(tokens)) + ")"
+
+
+compose_item_handle.simple = True
 
 
 def tco_return_handle(tokens):

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -1657,12 +1657,12 @@ class Grammar(object):
         + ZeroOrMore(fixto(semicolon, "\n") + simple_stmt_item)
         + (newline | endline_semicolon),
     ))
-    stmt <<= trace(final(compound_stmt | simple_stmt))
+    stmt <<= trace(compound_stmt | simple_stmt)
     base_suite <<= condense(newline + indent - OneOrMore(stmt) - dedent)
     simple_suite = attach(simple_stmt, make_suite_handle)
-    nocolon_suite <<= trace(base_suite | simple_suite)
+    nocolon_suite <<= trace(final(base_suite | simple_suite))
     suite <<= condense(colon + nocolon_suite)
-    line = trace(newline | stmt)
+    line = trace(final(newline | stmt))
 
     single_input = trace(condense(Optional(line) - ZeroOrMore(newline)))
     file_input = trace(condense(moduledoc_marker - ZeroOrMore(line)))

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -1657,13 +1657,12 @@ class Grammar(object):
         + ZeroOrMore(fixto(semicolon, "\n") + simple_stmt_item)
         + (newline | endline_semicolon),
     ))
-    stmt <<= trace(compound_stmt | simple_stmt)
+    stmt <<= trace(final(compound_stmt | simple_stmt))
     base_suite <<= condense(newline + indent - OneOrMore(stmt) - dedent)
     simple_suite = attach(simple_stmt, make_suite_handle)
     nocolon_suite <<= trace(base_suite | simple_suite)
     suite <<= condense(colon + nocolon_suite)
-
-    line = trace(final(newline | stmt))
+    line = trace(newline | stmt)
 
     single_input = trace(condense(Optional(line) - ZeroOrMore(newline)))
     file_input = trace(condense(moduledoc_marker - ZeroOrMore(line)))

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -1660,7 +1660,7 @@ class Grammar(object):
     stmt <<= trace(compound_stmt | simple_stmt)
     base_suite <<= condense(newline + indent - OneOrMore(stmt) - dedent)
     simple_suite = attach(simple_stmt, make_suite_handle)
-    nocolon_suite <<= trace(final(base_suite | simple_suite))
+    nocolon_suite <<= trace(base_suite | simple_suite)
     suite <<= condense(colon + nocolon_suite)
     line = trace(final(newline | stmt))
 

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -32,7 +32,6 @@ from functools import reduce
 
 from coconut.pyparsing import (
     CaselessLiteral,
-    Combine,
     Forward,
     Group,
     Keyword,
@@ -73,6 +72,7 @@ from coconut.constants import (
 )
 from coconut.compiler.matching import Matcher
 from coconut.compiler.util import (
+    CombineNode as Combine,
     attach,
     fixto,
     addspace,

--- a/coconut/compiler/matching.py
+++ b/coconut/compiler/matching.py
@@ -45,14 +45,14 @@ from coconut.compiler.util import paren_join
 def get_match_names(match):
     """Gets keyword names for the given match."""
     names = []
-    if "paren" in match.keys():
+    if "paren" in match:
         (match,) = match
         names += get_match_names(match)
-    elif "var" in match.keys():
+    elif "var" in match:
         (setvar,) = match
         if setvar != wildcard:
             names.append(setvar)
-    elif "trailer" in match.keys():
+    elif "trailer" in match:
         match, trailers = match[0], match[1:]
         for i in range(0, len(trailers), 2):
             op, arg = trailers[i], trailers[i + 1]
@@ -609,7 +609,7 @@ class Matcher(object):
     def match(self, tokens, item):
         """Performs pattern-matching processing."""
         for flag, get_handler in self.matchers.items():
-            if flag in tokens.keys():
+            if flag in tokens:
                 return get_handler(self)(tokens, item)
         raise CoconutInternalException("invalid pattern-matching tokens", tokens)
 

--- a/coconut/compiler/matching.py
+++ b/coconut/compiler/matching.py
@@ -394,7 +394,7 @@ class Matcher(object):
         else:
             self.add_check("_coconut.len(" + item + ") >= " + str(len(matches)))
             if tail != wildcard:
-                if len(matches):
+                if len(matches) > 0:
                     splice = "[" + str(len(matches)) + ":]"
                 else:
                     splice = ""

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -175,6 +175,11 @@ def attach(item, action, simple=None, greedy=False):
     return add_action(item, partial(ComputationNode, action, simple=simple, greedy=greedy))
 
 
+def final(item):
+    """Designate an item as having no backtracking."""
+    return add_action(item, evaluate_tokens)
+
+
 def unpack(tokens):
     """Evaluate and unpack the given computation graph."""
     logger.log_tag("unpack", tokens)

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -76,7 +76,7 @@ def evaluate_tokens(tokens):
                     try:
                         new_value = new_toklist[toklist.index(value)]
                     except ValueError:
-                        complain(CoconutInternalException("inefficient re-parsing of tokens: {} not in {}".format(
+                        complain(lambda: CoconutInternalException("inefficient reevaluation of tokens: {} not in {}".format(
                             value,
                             toklist,
                         )))
@@ -429,6 +429,7 @@ def transform(grammar, text):
 
 class Wrap(ParseElementEnhance):
     """PyParsing token that wraps the given item in the given context manager."""
+    __slots__ = ("errmsg", "wrapper")
 
     def __init__(self, item, wrapper):
         super(Wrap, self).__init__(item)

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -270,8 +270,6 @@ def addskip(skips, skip):
     """Add a line skip to the skips."""
     if skip < 1:
         complain(CoconutInternalException("invalid skip of line " + str(skip)))
-    elif DEVELOP and skip in skips:  # avoid the overhead of the check if not in develop
-        raise CoconutInternalException("duplicate skip of line " + str(skip))
     else:
         skips.append(skip)
     return skips

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -131,7 +131,7 @@ class ComputationNode(object):
     def compute_result(self):
         """Evaluate the computation graph at this node and assign the result to self.result."""
         evaluated_toks = evaluate_tokens(self.tokens)
-        if logger.tracing:  # avoid the overhead of the call when not tracing
+        if logger.tracing:  # avoid the overhead of the call if not tracing
             logger.log_trace(self.name, self.original, self.loc, evaluated_toks, self.tokens)
         try:
             self.result = _trim_arity(self.action)(
@@ -270,8 +270,8 @@ def addskip(skips, skip):
     """Add a line skip to the skips."""
     if skip < 1:
         complain(CoconutInternalException("invalid skip of line " + str(skip)))
-    elif skip in skips:
-        complain(CoconutInternalException("duplicate skip of line " + str(skip)))
+    elif DEVELOP and skip in skips:  # avoid the overhead of the check if not in develop
+        raise CoconutInternalException("duplicate skip of line " + str(skip))
     else:
         skips.add(skip)
     return skips

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -53,7 +53,6 @@ from coconut.exceptions import (
     internal_assert,
 )
 
-
 #-----------------------------------------------------------------------------------------------------------------------
 # COMPUTATION GRAPH:
 #-----------------------------------------------------------------------------------------------------------------------
@@ -187,7 +186,7 @@ def attach(item, action, simple=None, greedy=False):
 
 
 def final(item):
-    """Designate an item as having no backtracking."""
+    """Collapse the computation graph upon parsing the given item."""
     if use_computation_graph:
         item = add_action(item, evaluate_tokens)
     return item
@@ -402,6 +401,7 @@ def transform(grammar, text):
     intervals = []
     for result, start, stop in all_matches(grammar, text):
         if result is not ignore_transform:
+            internal_assert(isinstance(result, str), "got non-string transform result", result)
             results.append(result)
             intervals.append((start, stop))
 

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -131,7 +131,7 @@ class ComputationNode(object):
     def compute_result(self):
         """Evaluate the computation graph at this node and assign the result to self.result."""
         evaluated_toks = evaluate_tokens(self.tokens)
-        if logger.tracing:  # avoid the overhead of the call if we're not tracing
+        if logger.tracing:  # avoid the overhead of the call when not tracing
             logger.log_trace(self.name, self.original, self.loc, evaluated_toks, self.tokens)
         try:
             self.result = _trim_arity(self.action)(

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -86,8 +86,9 @@ def evaluate_tokens(tokens):
 
 class ComputationNode(object):
     """A single node in the computation graph."""
+    __slots__ = ("action", "loc", "tokens", "index_of_original", "result")
     list_of_originals = []
-    result = no_result = object()
+    no_result = object()
 
     def __new__(cls, action, original, loc, tokens, simple=False):
         """Create a ComputionNode to return from a parse action."""
@@ -95,6 +96,7 @@ class ComputationNode(object):
             return tokens[0]  # could be a ComputationNode, so we can't have an __init__
         else:
             self = super(ComputationNode, cls).__new__(cls)
+            self.result = cls.no_result
             self.action, self.loc, self.tokens = action, loc, tokens
             try:
                 self.index_of_original = self.list_of_originals.index(original)
@@ -117,6 +119,7 @@ class ComputationNode(object):
         """Get the result of evaluating the computation graph at this node."""
         if self.result is self.no_result:
             self.compute_result()
+        internal_assert(self.result is not self.no_result, "got no result computing action " + self.name + " of graph", self.tokens)
         return self.result
 
     def compute_result(self):
@@ -134,7 +137,7 @@ class ComputationNode(object):
             raise
         except (Exception, AssertionError):
             traceback.print_exc()
-            raise CoconutInternalException("error computing action " + self.name + " with tokens", evaluated_toks)
+            raise CoconutInternalException("error computing action " + self.name + " of tokens", evaluated_toks)
 
     def __repr__(self):
         """Get a representation of the entire computation graph below this node."""
@@ -144,6 +147,7 @@ class ComputationNode(object):
 
 class CombineNode(Combine):
     """Modified Combine to work with the computation graph."""
+    __slots__ = ()
 
     def _action(self, original, loc, tokens):
         """Implement the parse action for Combine."""

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -63,9 +63,11 @@ def evaluate_tokens(tokens):
     if isinstance(tokens, str):
         return tokens
     elif isinstance(tokens, ParseResults):
+        # evaluate the list portion of the ParseResults
         toklist, name, asList, modal = tokens.__getnewargs__()
         new_toklist = [evaluate_tokens(toks) for toks in toklist]
         new_tokens = ParseResults(new_toklist, name, asList, modal)
+        # evaluate the dictionary portion of the ParseResults
         new_tokdict = {}
         for name, occurrences in tokens._ParseResults__tokdict.items():
             new_occurences = []
@@ -260,7 +262,7 @@ skip_whitespace = SkipTo(CharsNotIn(default_whitespace_chars)).suppress()
 
 def longest(*args):
     """Match the longest of the given grammar elements."""
-    internal_assert(len(args) >= 2, "longest expected at least two args")
+    internal_assert(len(args) >= 2, "longest expects at least two args")
     matcher = args[0] + skip_whitespace
     for elem in args[1:]:
         matcher ^= elem + skip_whitespace

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -273,7 +273,7 @@ def addskip(skips, skip):
     elif DEVELOP and skip in skips:  # avoid the overhead of the check if not in develop
         raise CoconutInternalException("duplicate skip of line " + str(skip))
     else:
-        skips.add(skip)
+        skips.append(skip)
     return skips
 
 

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -110,6 +110,7 @@ all_reqs = {
     "dev": (
         "pre-commit",
         "requests",
+        "vprof",
     ),
     "docs": (
         "sphinx",
@@ -144,6 +145,7 @@ min_versions = {
     "pexpect": (4,),
     "watchdog": (0, 8),
     "requests": (2,),
+    "vprof": (0, 37),
     # We can't upgrade this; it breaks on Python 2.
     "ipython": (5, 4),
     # Don't upgrade these; they break on master!

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -280,6 +280,8 @@ varchars = string.ascii_letters + string.digits + "_"
 # COMPILER CONSTANTS:
 #-----------------------------------------------------------------------------------------------------------------------
 
+use_computation_graph = True
+
 template_ext = ".py_template"
 
 default_encoding = "utf-8"

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -270,8 +270,7 @@ script_names = (
 # PYPARSING CONSTANTS:
 #-----------------------------------------------------------------------------------------------------------------------
 
-packrat_cache_size = 512
-use_packrat = packrat_cache_size != 0
+packrat_cache = 512
 
 default_whitespace_chars = " \t\f\v\xa0"  # we don't include \r here because the compiler converts \r into \n
 

--- a/coconut/exceptions.py
+++ b/coconut/exceptions.py
@@ -64,11 +64,11 @@ def internal_assert(condition, message=None, item=None, extra=None):
     If condition is a function, execute it on DEVELOP only."""
     if DEVELOP and callable(condition):
         condition = condition()
-    if message is None:
-        message = "assertion failed"
-        if item is None:
-            item = condition
     if not condition:
+        if message is None:
+            message = "assertion failed"
+            if item is None:
+                item = condition
         raise CoconutInternalException(message, item, extra)
 
 

--- a/coconut/exceptions.py
+++ b/coconut/exceptions.py
@@ -44,7 +44,7 @@ def get_encoding(fileobj):
 
 
 def clean(inputline, strip=True, rem_indents=True, encoding_errors="replace"):
-    """Clean and strips a line."""
+    """Clean and strip a line."""
     stdout_encoding = get_encoding(sys.stdout)
     inputline = str(inputline)
     if rem_indents:
@@ -54,9 +54,9 @@ def clean(inputline, strip=True, rem_indents=True, encoding_errors="replace"):
     return inputline.encode(stdout_encoding, encoding_errors).decode(stdout_encoding)
 
 
-def debug_clean(inputline, strip=True):
-    """Call clean with debug parameters."""
-    return clean(inputline, strip, rem_indents=False, encoding_errors="backslashreplace")
+def displayable(inputstr, strip=True):
+    """Make a string displayable with minimal loss of information."""
+    return clean(str(inputstr), strip, rem_indents=False, encoding_errors="backslashreplace")
 
 
 def internal_assert(condition, message=None, item=None, extra=None):

--- a/coconut/pyparsing.py
+++ b/coconut/pyparsing.py
@@ -33,16 +33,20 @@ from coconut.constants import (
 
 try:
     from cPyparsing import *  # NOQA
-    from cPyparsing import __version__
-    if DEVELOP:
-        from cPyparsing import _trim_arity  # NOQA
+    from cPyparsing import (  # NOQA
+        _trim_arity,
+        _ParseResultsWithOffset,
+        __version__,
+    )
     PYPARSING = "Cython cPyparsing v" + __version__
 
 except ImportError:
     from pyparsing import *  # NOQA
-    from pyparsing import __version__
-    if DEVELOP:
-        from pyparsing import _trim_arity  # NOQA
+    from pyparsing import (  # NOQA
+        _trim_arity,
+        _ParseResultsWithOffset,
+        __version__,
+    )
     PYPARSING = "Python pyparsing v" + __version__
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/coconut/pyparsing.py
+++ b/coconut/pyparsing.py
@@ -24,8 +24,7 @@ from coconut.requirements import (
     ver_tuple_to_str,
 )
 from coconut.constants import (
-    use_packrat,
-    packrat_cache_size,
+    packrat_cache,
     default_whitespace_chars,
     varchars,
     min_versions,
@@ -62,8 +61,8 @@ if ver_str_to_tuple(__version__) < min_versions["pyparsing"]:
         + " 'pip install --upgrade cPyparsing' to fix)",
     )
 
-if use_packrat:
-    ParserElement.enablePackrat(packrat_cache_size)
+if packrat_cache:
+    ParserElement.enablePackrat(packrat_cache)
 
 ParserElement.setDefaultWhitespaceChars(default_whitespace_chars)
 

--- a/coconut/terminal.py
+++ b/coconut/terminal.py
@@ -211,6 +211,8 @@ class Logger(object):
     def log_tag(self, tag, code, multiline=False):
         """Logs a tagged message if tracing."""
         if self.tracing:
+            if callable(code):
+                code = code()
             tagstr = "[" + str(tag) + "]"
             if multiline:
                 printerr(tagstr + "\n" + displayable(code))

--- a/coconut/terminal.py
+++ b/coconut/terminal.py
@@ -244,7 +244,7 @@ class Logger(object):
                 printerr(*out)
 
     def _trace_start_action(self, original, loc, expr):
-        self.log_trace(expr, original, loc)
+        pass  # we'd rather log after the action when we know its result
 
     def _trace_success_action(self, original, start_loc, end_loc, expr, tokens):
         self.log_trace(expr, original, start_loc, tokens)

--- a/coconut/terminal.py
+++ b/coconut/terminal.py
@@ -69,7 +69,10 @@ def format_error(err_type, err_value, err_trace=None):
 
 def complain(error):
     """Raises in develop; warns in release."""
-    if DEVELOP:
+    if callable(error):
+        if DEVELOP:
+            raise error()
+    elif DEVELOP:
         raise error
     else:
         logger.warn_err(error)

--- a/coconut/terminal.py
+++ b/coconut/terminal.py
@@ -245,9 +245,6 @@ class Logger(object):
                     out.append("from " + ascii(extra))
                 printerr(*out)
 
-    def _trace_start_action(self, original, loc, expr):
-        pass  # we'd rather log after the action when we know its result
-
     def _trace_success_action(self, original, start_loc, end_loc, expr, tokens):
         self.log_trace(expr, original, start_loc, tokens)
 
@@ -257,11 +254,12 @@ class Logger(object):
     def trace(self, item):
         """Traces a parse element (only enabled in develop)."""
         if DEVELOP:
-            item = item.setDebugActions(
-                self._trace_start_action,
+            item.debugActions = (
+                None,  # no start action
                 self._trace_success_action,
                 self._trace_exc_action,
             )
+            item.debug = True
         return item
 
     @contextmanager

--- a/coconut/terminal.py
+++ b/coconut/terminal.py
@@ -35,7 +35,7 @@ from coconut.constants import (
     info_tabulation,
     main_sig,
     taberrfmt,
-    use_packrat,
+    packrat_cache,
 )
 from coconut.exceptions import (
     CoconutWarning,
@@ -240,7 +240,7 @@ class Logger(object):
                 if add_line_col:
                     out.append("(line:" + str(lineno(loc, original)) + ", col:" + str(col(loc, original)) + ")")
                 if extra is not None:
-                    out.append("from " + displayable(extra))
+                    out.append("from " + ascii(extra))
                 printerr(*out)
 
     def _trace_start_action(self, original, loc, expr):
@@ -272,7 +272,7 @@ class Logger(object):
             finally:
                 elapsed_time = time.clock() - start_time
                 printerr("Time while parsing:", elapsed_time, "seconds")
-                if use_packrat:
+                if packrat_cache:
                     hits, misses = ParserElement.packrat_cache_stats
                     printerr("Packrat parsing stats:", hits, "hits;", misses, "misses")
         else:


### PR DESCRIPTION
Instead of greedily applying parse actions, build a computation graph that only gets executed after everything has been parsed. Implements #299.