### PR TITLE
Added missing pygments.styles import.

### DIFF
--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -70,6 +70,7 @@ from coconut import __coconut__
 try:
     import prompt_toolkit
     import pygments
+    import pygments.styles
     from coconut.highlighter import CoconutLexer
 except ImportError:
     prompt_toolkit = None


### PR DESCRIPTION
While trying to make coconut run on prompt_toolkit 2.0, I discovered that this Pygments import was missing.
```python
Traceback (most recent call last):
  File "/home/jonathan/git/coconut/coconut/command/command.py", line 270, in handling_exceptions
    yield
  File "/home/jonathan/git/coconut/coconut/command/command.py", line 118, in cmd
    self.use_args(parsed_args, interact, original_args=args)
  File "/home/jonathan/git/coconut/coconut/command/command.py", line 156, in use_args
    self.prompt.set_style(args.style)
  File "/home/jonathan/git/coconut/coconut/command/util.py", line 332, in set_style
    elif style in pygments.styles.get_all_styles():
AttributeError: module 'pygments' has no attribute 'styles'
```

Maybe this wasn't required in prompt_toolkit 1.0 because prompt_toolkit did this import for you. For 2.0, we don't require Pygments anymore.