### PR TITLE
add support for a history file in the repl

### DIFF
--- a/coconut/command/cli.py
+++ b/coconut/command/cli.py
@@ -26,7 +26,9 @@ from coconut.constants import (
     version_long,
     default_recursion_limit,
     style_env_var,
+    histfile_env_var,
     default_style,
+    default_histfile,
     main_sig,
 )
 
@@ -206,6 +208,14 @@ arguments.add_argument(
     type=str,
     help="Pygments syntax highlighting style (or 'none' to disable) (defaults to "
     + style_env_var + " environment variable, if it exists, otherwise '" + default_style + "')",
+)
+
+arguments.add_argument(
+    "--history-file",
+    metavar="path",
+    type=str,
+    help="Path to history file (or '' for no file) (defaults to "
+    + histfile_env_var + " environment variable if it exists, otherwise '" + default_histfile + "')",
 )
 
 arguments.add_argument(

--- a/coconut/command/command.py
+++ b/coconut/command/command.py
@@ -160,6 +160,8 @@ class Command(object):
             self.show = True
         if args.style is not None:
             self.prompt.set_style(args.style)
+        if args.history_file is not None:
+            self.prompt.set_history_file(args.history_file)
         if args.documentation:
             launch_documentation()
         if args.tutorial:

--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -41,6 +41,7 @@ from coconut.constants import (
     main_prompt,
     more_prompt,
     default_style,
+    default_histfile,
     prompt_multiline,
     prompt_vi_mode,
     prompt_mouse_support,
@@ -334,7 +335,6 @@ def canparse(argparser, args):
 # CLASSES:
 #-----------------------------------------------------------------------------------------------------------------------
 
-
 class Prompt(object):
     """Manages prompting for code on the command line."""
     style = None
@@ -352,10 +352,7 @@ class Prompt(object):
             else:
                 self.style = default_style
 
-            if histfile_env_var in os.environ and os.environ[histfile_env_var]:
-                self.history = prompt_toolkit.history.FileHistory(os.environ[histfile_env_var])
-            else:
-                self.history = prompt_toolkit.history.InMemoryHistory()
+            self.set_history_file(os.environ.get(histfile_env_var, default_histfile))
 
     def set_style(self, style):
         """Set pygments syntax highlighting style."""
@@ -370,6 +367,15 @@ class Prompt(object):
             self.style = style
         else:
             raise CoconutException("unrecognized pygments style", style, extra="use '--style list' to show all valid styles")
+
+    def set_history_file(self, path):
+        """Set path to history file. "" produces no file."""
+        assert isinstance(path, str)
+
+        if path == "":
+            self.history = prompt_toolkit.history.InMemoryHistory()
+        else:
+            self.history = prompt_toolkit.history.FileHistory(path)
 
     def input(self, more=False):
         """Prompt for code input."""

--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -48,6 +48,7 @@ from coconut.constants import (
     prompt_history_search,
     style_env_var,
     mypy_path_env_var,
+    histfile_env_var,
     tutorial_url,
     documentation_url,
     reserved_vars,
@@ -350,7 +351,11 @@ class Prompt(object):
                 self.set_style(os.environ[style_env_var])
             else:
                 self.style = default_style
-            self.history = prompt_toolkit.history.InMemoryHistory()
+
+            if histfile_env_var in os.environ and os.environ[histfile_env_var]:
+                self.history = prompt_toolkit.history.FileHistory(os.environ[histfile_env_var])
+            else:
+                self.history = prompt_toolkit.history.InMemoryHistory()
 
     def set_style(self, style):
         """Set pygments syntax highlighting style."""

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -489,6 +489,7 @@ main_prompt = ">>> "
 more_prompt = "    "
 
 default_style = "default"
+default_histfile = ""
 prompt_multiline = False
 prompt_vi_mode = False
 prompt_mouse_support = False  # causes problems in unix shells

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -497,6 +497,7 @@ prompt_history_search = True
 
 mypy_path_env_var = "MYPYPATH"
 style_env_var = "COCONUT_STYLE"
+histfile_env_var = "COCONUT_HISTORY"
 
 watch_interval = .1  # seconds
 


### PR DESCRIPTION
This seemed straightforward enough to add that I figured I would just submit a PR.

This adds the environment var `COCONUT_HISTORY` for setting a path for a persistent history file (using the existing facilities of `prompt_toolkit`).

I also added a CLI argument `--history-file=PATH` ~~because I didn't see other any place to document the env var~~ because why not.

(note: the default is still set to no history file.  Users may be sad to discover that `.python_history` and `prompt_toolkit` use different formats; you need to use something else like `$HOME/.coconut_history`.  Maybe that should be the default instead)