### PR TITLE
Make autopep8 leave the dividers alone

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         - --aggressive
         - --aggressive
         - --experimental
-        - --ignore=W503,E501,E722
+        - --ignore=W503,E501,E722,E265
     -   id: flake8
         args:
         - --ignore=W503,E501,E265,E402,F405,E305


### PR DESCRIPTION
E265 is "block comment should begin with '# '".  It makes autopep8 want to do this all over the codebase, as I ran into when fixing up #422.

```diff
diff --git a/coconut/command/util.py b/coconut/command/util.py
index ed260db..05edf4f 100644
--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#-----------------------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------------------
 # INFO:
-#-----------------------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------------------
 
 """
 Authors: Evan Hubinger, Fred Buchanan
@@ -11,9 +11,9 @@ License: Apache 2.0
 Description: Utility functions for the main command module.
 """
 
-#-----------------------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------------------
 # IMPORTS:
-#-----------------------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------------------
```

---

I do have to wonder though how it hasn't caused any issue in the past...?  Even if the feature was a brand new addition of autopep8, the latest release was 13 days ago...

**Edit:** Ah! But it is indeed the latest release that changed this behavior: https://github.com/hhatto/autopep8/issues/389