### PR TITLE
Add __hash__ on data types

### DIFF
--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -1260,6 +1260,8 @@ class Compiler(Grammar):
 __ne__ = _coconut.object.__ne__
 def __eq__(self, other):
     {oind}return self.__class__ is other.__class__ and _coconut.tuple.__eq__(self, other)
+{cind}def __hash__(self):
+    {oind}return _coconut.tuple.__hash__(self) ^ hash(self.__class__)
 {cind}'''.format(
             oind=openindent,
             cind=closeindent,

--- a/tests/src/cocotest/agnostic/main.coco
+++ b/tests/src/cocotest/agnostic/main.coco
@@ -267,6 +267,8 @@ def main_test():
     assert issubclass(abc_, object)
     assert isinstance(abc(10), object)
     assert isinstance(abc_(10), object)
+    assert hash(abc(10)) == hash(abc(10))
+    assert hash(abc(10)) != hash(abc_(10)) != hash((10,))
     class aclass
     assert issubclass(aclass, object)
     assert isinstance(aclass(), object)


### PR DESCRIPTION
The added implementation XORs the `tuple.__hash__` of the data object with the hash of the class.  This should help to avoid collisions between instances of different data types with identical members.

Also added a test which ensures that:
* hash of a data type instance can be computed;
* hashes of instances of different data types with same data differ;
* hash of a data type instance differs from hash of a plain tuple.

Fixes #446.