### PR TITLE
Raise CoconutSyntaxError for explicit returns in assignment functions

### DIFF
--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -487,6 +487,11 @@ def make_suite_handle(tokens):
     return "\n" + openindent + tokens[0] + closeindent
 
 
+def invalid_return_stmt_handle(_, loc, __):
+    """Raise a syntax error if encountered a return statement where an implicit return is expected."""
+    raise CoconutDeferredSyntaxError("Expected expression but got return statement", loc)
+
+
 def implicit_return_handle(tokens):
     """Add an implicit return."""
     internal_assert(len(tokens) == 1, "invalid implicit return tokens", tokens)
@@ -1484,7 +1489,10 @@ class Grammar(object):
     )
     where_stmt = attach(unsafe_simple_stmt_item + keyword("where").suppress() - where_suite, where_stmt_handle)
 
-    implicit_return = attach(testlist, implicit_return_handle)
+    implicit_return = (
+        attach(return_stmt, invalid_return_stmt_handle)
+        | attach(testlist, implicit_return_handle)
+    )
     implicit_return_stmt = (
         attach(implicit_return + keyword("where").suppress() - where_suite, where_stmt_handle)
         | condense(implicit_return + newline)

--- a/tests/src/extras.coco
+++ b/tests/src/extras.coco
@@ -93,6 +93,8 @@ def main():
     assert_raises(-> parse("f''"), CoconutException)
     assert_raises(-> parse("f$()"), CoconutSyntaxError)
     assert_raises(-> parse("f(*x, y)"), CoconutSyntaxError)
+    assert_raises(-> parse("def f(x) = return x"), CoconutSyntaxError)
+    assert_raises(-> parse("def f(x) =\n return x"), CoconutSyntaxError)
     setup(target="2.7")
     assert parse("from io import BytesIO", mode="debug") == "from io import BytesIO"
     assert_raises(-> parse("def f(*, x=None) = x"), CoconutTargetError)


### PR DESCRIPTION
This change covers the cases like:

    def f(x) = return x

or

    def f(x) =
        return x

These previously used to raise CoconutParseErrors, and this was not obvious what should be done to fix the code.  With this change the errors are raised with a meaningful error message.

Fixes #354.