### PR TITLE
Fix addpattern incorrectly catching all MatchErrors

### DIFF
--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -72,6 +72,7 @@ from coconut.constants import (
     checksum,
     reserved_prefix,
     case_check_var,
+    function_match_error_var,
 )
 from coconut.exceptions import (
     CoconutException,
@@ -1409,14 +1410,14 @@ def __eq__(self, other):
             key, val, comp = tokens
             return "dict(((" + key + "), (" + val + ")) " + comp + ")"
 
-    def pattern_error(self, original, loc, value_var, check_var):
+    def pattern_error(self, original, loc, value_var, check_var, match_error_class='_coconut_MatchError'):
         """Construct a pattern-matching error message."""
         base_line = clean(self.reformat(getline(loc, original)))
         line_wrap = self.wrap_str_of(base_line)
         repr_wrap = self.wrap_str_of(ascii(base_line))
         return (
             "if not " + check_var + ":\n" + openindent
-            + match_err_var + ' = _coconut_MatchError("pattern-matching failed for " '
+            + match_err_var + " = " + match_error_class + '("pattern-matching failed for " '
             + repr_wrap + ' " in " + _coconut.repr(_coconut.repr(' + value_var + ")))\n"
             + match_err_var + ".pattern = " + line_wrap + "\n"
             + match_err_var + ".value = " + value_var
@@ -1457,7 +1458,8 @@ def __eq__(self, other):
             match_check_var + " = False\n"
             + matcher.out()
             # we only include match_to_args_var here because match_to_kwargs_var is modified during matching
-            + self.pattern_error(original, loc, match_to_args_var, match_check_var) + closeindent
+            + self.pattern_error(original, loc, match_to_args_var, match_check_var, function_match_error_var)
+            + closeindent
         )
         return before_docstring, after_docstring
 

--- a/coconut/compiler/header.py
+++ b/coconut/compiler/header.py
@@ -205,7 +205,7 @@ else:
         ),
     )
 
-    format_dict["underscore_imports"] = "_coconut, _coconut_NamedTuple, _coconut_MatchError{comma_tco}, _coconut_igetitem, _coconut_base_compose, _coconut_forward_compose, _coconut_back_compose, _coconut_forward_star_compose, _coconut_back_star_compose, _coconut_pipe, _coconut_star_pipe, _coconut_back_pipe, _coconut_back_star_pipe, _coconut_bool_and, _coconut_bool_or, _coconut_none_coalesce, _coconut_minus, _coconut_map, _coconut_partial".format(**format_dict)
+    format_dict["underscore_imports"] = "_coconut, _coconut_NamedTuple, _coconut_MatchError{comma_tco}, _coconut_igetitem, _coconut_base_compose, _coconut_forward_compose, _coconut_back_compose, _coconut_forward_star_compose, _coconut_back_star_compose, _coconut_pipe, _coconut_star_pipe, _coconut_back_pipe, _coconut_back_star_pipe, _coconut_bool_and, _coconut_bool_or, _coconut_none_coalesce, _coconut_minus, _coconut_map, _coconut_partial, _coconut_get_function_match_error".format(**format_dict)
 
     # ._coconut_tco_func is used in main.coco, so don't remove it
     #  here without replacing its usage there

--- a/coconut/compiler/matching.py
+++ b/coconut/compiler/matching.py
@@ -33,6 +33,7 @@ from coconut.constants import (
     closeindent,
     const_vars,
     sentinel_var,
+    function_match_error_var,
 )
 from coconut.compiler.util import paren_join
 
@@ -251,6 +252,11 @@ class Matcher(object):
 
     def match_in_args_kwargs(self, match_args, args, kwargs, allow_star_args=False):
         """Matches against args or kwargs."""
+
+        # before everything, pop the FunctionMatchError from context
+        self.add_def(function_match_error_var + " = _coconut_get_function_match_error()")
+        self.increment()
+
         req_len = 0
         arg_checks = {}
         to_match = []  # [(move_down, match, against)]

--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -399,15 +399,41 @@ def recursive_iterator(func):
             tee_store[key], to_return = _coconut_tee(tee_store.get(key) or func(*args, **kwargs))
         return to_return
     return recursive_iterator_func
+class _coconut_FunctionMatchErrorContext(object):
+    from threading import local; threadlocal_var = local(); del local
+    __slots__ = ('exc_class', 'taken')
+    def __init__(self, exc_class):
+        self.exc_class = exc_class
+        self.taken = False
+    def __enter__(self):
+        try:
+            self.threadlocal_var.contexts.append(self)
+        except AttributeError:
+            self.threadlocal_var.contexts = [self]
+    def __exit__(self, type, value, traceback):
+        self.threadlocal_var.contexts.pop()
+    @classmethod
+    def get(cls):
+        try:
+            ctx = cls.threadlocal_var.contexts[-1]
+        except (AttributeError, IndexError):
+            return MatchError
+        if not ctx.taken:
+            ctx.taken = True
+            return ctx.exc_class
+        return MatchError
+_coconut_get_function_match_error = _coconut_FunctionMatchErrorContext.get
 def addpattern(base_func):
     """Decorator to add a new case to a pattern-matching function,
     where the new case is checked last."""
     def pattern_adder(func):
+        FunctionMatchError = type(_coconut_str("MatchError"), (MatchError,), {{}})
         {tco_decorator}@_coconut.functools.wraps(func)
         def add_pattern_func(*args, **kwargs):
             try:
-                return base_func(*args, **kwargs)
-            except _coconut_MatchError:
+                with _coconut_FunctionMatchErrorContext(FunctionMatchError):
+                    return base_func(*args, **kwargs)
+            except FunctionMatchError:
                 return {tail_call_func_args_kwargs}
         return add_pattern_func
     return pattern_adder

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -388,6 +388,7 @@ match_check_var = reserved_prefix + "_match_check"
 match_temp_var = reserved_prefix + "_match_temp"
 match_err_var = reserved_prefix + "_match_err"
 case_check_var = reserved_prefix + "_case_check"
+function_match_error_var = reserved_prefix + "_FunctionMatchError"
 
 wildcard = "_"  # for pattern-matching
 

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -41,6 +41,7 @@ PY26 = _coconut_sys.version_info < (2, 7)
 
 PY3_HEADER = r'''from builtins import chr, filter, hex, input, int, map, object, oct, open, print, range, str, zip, filter, reversed, enumerate
 py_chr, py_hex, py_input, py_int, py_map, py_object, py_oct, py_open, py_print, py_range, py_str, py_zip, py_filter, py_reversed, py_enumerate = chr, hex, input, int, map, object, oct, open, print, range, str, zip, filter, reversed, enumerate
+_coconut_str = str
 '''
 
 PY27_HEADER = r'''from __builtin__ import chr, filter, hex, input, int, map, object, oct, open, print, range, str, zip, filter, reversed, enumerate, raw_input, xrange

--- a/coconut/stubs/__coconut__.pyi
+++ b/coconut/stubs/__coconut__.pyi
@@ -114,6 +114,9 @@ class MatchError(Exception): ...
 _coconut_MatchError = MatchError
 
 
+def _coconut_get_function_match_error() -> _t.Type[MatchError]: ...
+
+
 def _coconut_tco(func: _FUNC) -> _FUNC: ...
 def _coconut_tail_call(func, *args, **kwargs):
     return func(*args, **kwargs)

--- a/tests/src/cocotest/agnostic/suite.coco
+++ b/tests/src/cocotest/agnostic/suite.coco
@@ -503,6 +503,15 @@ def suite_test():
     assert join_pairs2([(1, [2]), (1, [3])]).items() |> list == [(1, [3, 2])]
     assert return_in_loop(10)
     assert methtest().meth(5) == 5
+    def test_match_error_addpattern(x is int): raise MatchError()
+    @addpattern(test_match_error_addpattern)
+    def test_match_error_addpattern(x) = x
+    try:
+        test_match_error_addpattern(0)
+    except MatchError as err:  # must not be caught inside addpattern
+        assert err
+    else:
+        assert False
     return True
 
 def tco_test():


### PR DESCRIPTION
This change introduces a context stack with MatchError subclasses that pattern-matching functions must raise instead of plain MatchError.

This works the following way:

* Every time a function is decorated with @addpattern, a subclass of MatchError is created and stored in the local scope;
* when such function is called, this subclass is put on the stack before execution of addpattern's base_func;
* when a pattern-matching function is called, it checks whether the exception class at the top of the stack has been already taken;
* if it wasn't, the function marks it as taken (so that no other function would take it from the stack) and will raise it instead of plain MatchError;
* inside addpattern, this specific exception is caught instead of MatchError.

As a result, any pattern-matching function called directly as addpattern's base_func will raise a specific subclass of MatchError but will not propagate it to any pattern-matching functions called inside.

The only case when addpattern will still catch a MatchError incorrectly is when addpattern wraps a non-pattern-matching function which calls a pattern-matching function internally (because the non-pattern-matching function will not mark the exception on the context stack as taken), but this should be extremely rare because addpattern is meant only for pattern-matching functions.

This is an alternative implementation of PR #435.