### PR TITLE
Change reiterable __copy__ method to use tee instead of copy, as copy depletes the iterator

### DIFF
--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -86,7 +86,8 @@ class reiterable{object}:
     def __reduce__(self):
         return (self.__class__, (self.iter,))
     def __copy__(self):
-        return self.__class__(_coconut.copy.copy(self.iter))
+        self.iter, new = _coconut_tee(self.iter)
+        return self.__class__(new)
     def __fmap__(self, func):
         return _coconut_map(func, self)
 class scan{object}:

--- a/tests/src/cocotest/agnostic/main.coco
+++ b/tests/src/cocotest/agnostic/main.coco
@@ -433,6 +433,15 @@ def main_test():
     assert a is None
     assert range(5) |> iter |> reiterable |> .[1] == 1
     assert range(5) |> reiterable |> fmap$(-> _ + 1) |> list == [1, 2, 3, 4, 5]  # type: ignore
+
+    a: Iterable[int] = [1] :: [2] :: [3]
+    a = a |> reiterable
+    b = a |> reiterable
+    assert b |> list == [1, 2, 3]
+    assert b |> list == [1, 2, 3]
+    assert a |> list == [1, 2, 3]
+    assert a |> list == [1, 2, 3]
+
     assert (+) ..*> (+) |> repr == "<built-in function add> ..*> <built-in function add>"
     assert scan((+), [1,2,3,4,5]) |> list == [1,3,6,10,15]
     assert scan((*), [1,2,3,4,5]) |> list == [1,2,6,24,120]


### PR DESCRIPTION
Hello, I found what I think is a bug and it's solution. Consider the following 
```
a = [2] :: [2]

a = a |> reiterable

b = a |> reiterable

b |> list |> print
b |> list |> print

a |> list |> print
a |> list |> print
```
Since both `a` and `b` are reiterable, I expect the output to be 
```
[2, 2]
[2, 2]
[2, 2]
[2, 2]
```
However the actual output is 
```
[2, 2]
[]
[]
[]
```
This is caused by the call to copy in the `__copy__` method in reiterable, which depletes the iterator. Instead of this I think tee should be used here to copy the iterator when making a new copy. The commit makes this change, which causes the above example to act as expected. I can add the above example as a test if you'd like