### PR TITLE
Add warning about nesting implicit lambdas to documentation

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -394,7 +394,7 @@ import random
 get_random_number = (-> random.random())
 ```
 
-_Note: Nesting implicit lambdas can lead to problems with the scope of the `\_` parameter to each lambda. It is recommended that nesting implicit lambdas be avoided._
+_Note: Nesting implicit lambdas can lead to problems with the scope of the `_` parameter to each lambda. It is recommended that nesting implicit lambdas be avoided._
 
 ### Partial Application
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -347,8 +347,6 @@ Note that because indexing has a greater precedence than piping, expressions of 
 
 Coconut provides the simple, clean `->` operator as an alternative to Python's `lambda` statements. The syntax for the `->` operator is `(parameters) -> expression` (or `parameter -> expression` for one-argument lambdas). The operator has the same precedence as the old statement, which means it will often be necessary to surround the lambda in parentheses, and is right-associative.
 
-Additionally, Coconut also supports an implicit usage of the `->` operator of the form `(-> expression)`, which is equivalent to `((_=None) -> expression)`, which allows an implicit lambda to be used both when no arguments are required, and when one argument (assigned to `_`) is required.
-
 _Note: If normal lambda syntax is insufficient, Coconut also supports an extended lambda syntax in the form of [statement lambdas](#statement-lambdas)._
 
 ##### Rationale
@@ -377,6 +375,26 @@ dubsums |> list |> print
 dubsums = map(lambda x, y: 2*(x+y), range(0, 10), range(10, 20))
 print(list(dubsums))
 ```
+
+#### Implicit Lambdas
+
+Coconut also supports implicit lambdas, which allow a lambda to take either no arguments or a single argument. Implicit lambdas are formed with the usual Coconut lambda operator `->`, in the form `(-> expression)`. This is equivalent to `((_=None) -> expression)`. When an argument is passed to an implicit lambda, it will be assigned to `_`, replacing the default value `None`.
+
+Below are two examples of implicit lambdas. The first uses the implicit argument `_`, while the second does not.
+
+**Single Argument Example:**
+```coconut
+square = (-> _**2)
+```
+
+**No-Argument Example:**
+```coconut
+import random
+
+get_random_number = (-> random.random())
+```
+
+_Note: Nesting implicit lambdas can lead to problems with the scope of the `\_` parameter to each lambda. It is recommended that nesting implicit lambdas be avoided._
 
 ### Partial Application
 


### PR DESCRIPTION
This makes the change to the documentation discussed in issue #479, adding more information on implicit lambdas and adding a warning about nesting multiple implicit lambdas.