### PR TITLE
Parse f-string expressions as Coconut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ After you've tested your changes locally, you'll want to add more permanent test
             - python35
                 - `py35_test.coco`
                     + Tests to be run only on Python 3.5 with `--target 3.5`.
+            - python36
+                - `py36_test.coco`
+                    + Tests to be run only on Python 3.6 with `--target 3.6`.
 
 ## Release Process
 

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -587,3 +587,17 @@ def disable_outside(item, *elems):
     """
     for wrapped in disable_inside(item, *elems, **{"_invert": True}):
         yield wrapped
+
+
+def interleaved_join(outer_list, inner_list):
+    """Interleaves two lists of strings and joins the result.
+
+    Example: interleaved_join(['1', '3'], ['2']) == '123'
+    The first list must be 1 longer than the second list.
+    """
+    internal_assert(len(outer_list) == len(inner_list) + 1, "invalid list lengths to interleaved_join")
+    interleaved = []
+    for xx in zip(outer_list, inner_list):
+        interleaved.extend(xx)
+    interleaved.append(outer_list[-1])
+    return "".join(interleaved)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -234,6 +234,11 @@ def comp_35(args=[], **kwargs):
     comp(path="cocotest", folder="target_35", args=["--target", "35"] + args, **kwargs)
 
 
+def comp_36(args=[], **kwargs):
+    """Compiles target_35."""
+    comp(path="cocotest", folder="target_36", args=["--target", "36"] + args, **kwargs)
+
+
 def comp_sys(args=[], **kwargs):
     """Compiles target_sys."""
     comp(path="cocotest", folder="target_sys", args=["--target", "sys"] + args, **kwargs)
@@ -264,6 +269,8 @@ def run(args=[], agnostic_target=None, use_run_arg=False, expect_retcode=0):
             comp_3(args, expect_retcode=expect_retcode)
             if sys.version_info >= (3, 5):
                 comp_35(args, expect_retcode=expect_retcode)
+            if sys.version_info >= (3, 6):
+                comp_36(args, expect_retcode=expect_retcode)
         comp_agnostic(agnostic_args, expect_retcode=expect_retcode)
         comp_sys(args, expect_retcode=expect_retcode)
 
@@ -328,6 +335,7 @@ def comp_all(args=[], **kwargs):
     comp_2(args, **kwargs)
     comp_3(args, **kwargs)
     comp_35(args, **kwargs)
+    comp_36(args, **kwargs)
     comp_agnostic(args, **kwargs)
     comp_sys(args, **kwargs)
     comp_runner(args, **kwargs)

--- a/tests/src/cocotest/agnostic/main.coco
+++ b/tests/src/cocotest/agnostic/main.coco
@@ -509,6 +509,7 @@ def main_test():
     assert f"{{" == "{"
     assert f"}}" == "}"
     assert f"{1, 2}" == "(1, 2)"
+    assert f"{[] |> len}" == "0"
     match {"a": {"b": x }} or {"a": {"b": {"c": x}}} = {"a": {"b": {"c": "x"}}}
     assert x == {"c": "x"}
     assert py_repr("x") == ("u'x'" if sys.version_info < (3,) else "'x'")
@@ -582,6 +583,9 @@ def main(*args):
         if sys.version_info >= (3, 5):
             from .py35_test import py35_test
             assert py35_test()
+        if sys.version_info >= (3, 6):
+            from .py36_test import py36_test
+            assert py36_test()
 
     print(".", end="")
     from .target_sys_test import target_sys_test

--- a/tests/src/cocotest/target_36/py36_test.coco
+++ b/tests/src/cocotest/target_36/py36_test.coco
@@ -1,0 +1,4 @@
+def py36_test():
+    """Performs Python-3.6-specific tests."""
+    assert f"{[] |> len}" == "0"
+    return True


### PR DESCRIPTION
This allows writing code like `f"{[] |> len}"`.

Fixes #504.