### PR TITLE
Add no-wrap Flag for optional typedef wrapping

### DIFF
--- a/coconut/command/cli.py
+++ b/coconut/command/cli.py
@@ -145,6 +145,12 @@ arguments.add_argument(
 )
 
 arguments.add_argument(
+    "--no-wrap", "--nowrap",
+    action="store_true",
+    help="disable wrapping type hints in strings",
+)
+
+arguments.add_argument(
     "-c", "--code",
     metavar="code",
     type=str,

--- a/coconut/command/command.py
+++ b/coconut/command/command.py
@@ -177,6 +177,7 @@ class Command(object):
             line_numbers=args.line_numbers,
             keep_lines=args.keep_lines,
             no_tco=args.no_tco,
+            no_wrap=args.no_wrap,
         )
 
         if args.mypy is not None:

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -408,7 +408,7 @@ class Compiler(Grammar):
         """Creates a new compiler with the given parsing parameters."""
         self.setup(*args, **kwargs)
 
-    def setup(self, target=None, strict=False, minify=False, line_numbers=False, keep_lines=False, no_tco=False):
+    def setup(self, target=None, strict=False, minify=False, line_numbers=False, keep_lines=False, no_tco=False, no_wrap=False):
         """Initializes parsing parameters."""
         if target is None:
             target = ""
@@ -428,10 +428,11 @@ class Compiler(Grammar):
         self.line_numbers = line_numbers
         self.keep_lines = keep_lines
         self.no_tco = no_tco
+        self.no_wrap = no_wrap
 
     def __reduce__(self):
         """Return pickling information."""
-        return (Compiler, (self.target, self.strict, self.minify, self.line_numbers, self.keep_lines, self.no_tco))
+        return (Compiler, (self.target, self.strict, self.minify, self.line_numbers, self.keep_lines, self.no_tco, self.no_wrap))
 
     def __copy__(self):
         """Create a new, blank copy of the compiler."""
@@ -1525,7 +1526,7 @@ def __new__(_cls, {all_args}):
 
         if types:
             namedtuple_call = '_coconut.typing.NamedTuple("' + name + '", [' + ", ".join(
-                '("' + argname + '", ' + self.wrap_typedef(types.get(i, "_coconut.typing.Any")) + ")"
+                '("' + argname + '", ' + (types.get(i, "_coconut.typing.Any") if self.no_wrap else self.wrap_typedef(types.get(i, "_coconut.typing.Any"))) + ")"
                 for i, argname in enumerate(base_args + ([starred_arg] if starred_arg is not None else []))
             ) + "])"
         else:
@@ -2073,7 +2074,7 @@ if not {check_var}:
         """Process Python 3 type annotations."""
         if len(tokens) == 1:  # return typedef
             if self.target.startswith("3"):
-                return " -> " + self.wrap_typedef(tokens[0]) + ":"
+                return " -> " + (tokens[0] if self.no_wrap else self.wrap_typedef(tokens[0])) + ":"
             else:
                 return ":\n" + self.wrap_comment(" type: (...) -> " + tokens[0])
         else:  # argument typedef
@@ -2085,7 +2086,7 @@ if not {check_var}:
             else:
                 raise CoconutInternalException("invalid type annotation tokens", tokens)
             if self.target.startswith("3"):
-                return varname + ": " + self.wrap_typedef(typedef) + default + comma
+                return varname + ": " + (typedef if self.no_wrap else self.wrap_typedef(typedef)) + default + comma
             else:
                 return varname + default + comma + self.wrap_passthrough(self.wrap_comment(" type: " + typedef) + "\n" + " " * self.tabideal)
 
@@ -2093,12 +2094,12 @@ if not {check_var}:
         """Process Python 3.6 variable type annotations."""
         if len(tokens) == 2:
             if self.target_info >= (3, 6):
-                return tokens[0] + ": " + self.wrap_typedef(tokens[1])
+                return tokens[0] + ": " + (tokens[1] if self.no_wrap else self.wrap_typedef(tokens[1]))
             else:
                 return tokens[0] + " = None" + self.wrap_comment(" type: " + tokens[1])
         elif len(tokens) == 3:
             if self.target_info >= (3, 6):
-                return tokens[0] + ": " + self.wrap_typedef(tokens[1]) + " = " + tokens[2]
+                return tokens[0] + ": " + (tokens[1] if self.no_wrap else self.wrap_typedef(tokens[1])) + " = " + tokens[2]
             else:
                 return tokens[0] + " = " + tokens[2] + self.wrap_comment(" type: " + tokens[1])
         else:


### PR DESCRIPTION
This adds a `no-wrap` flag to the compiler to disable wrapping typedefs to resolve #514 

I'm a bit mixed about the name of the flag, I feel like it's too ambiguous and I'm very much open to changing it.