### PR TITLE
docs: Fix simple typo, seperated -> separated

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1124,7 +1124,7 @@ g = def (a: int, b: int) -> a ** b
 
 ### Lazy Lists
 
-Coconut supports the creation of lazy lists, where the contents in the list will be treated as an iterator and not evaluated until they are needed. Lazy lists can be created in Coconut simply by simply surrounding a comma-seperated list of items with `(|` and `|)` (so-called "banana brackets") instead of `[` and `]` for a list or `(` and `)` for a tuple.
+Coconut supports the creation of lazy lists, where the contents in the list will be treated as an iterator and not evaluated until they are needed. Lazy lists can be created in Coconut simply by simply surrounding a comma-separated list of items with `(|` and `|)` (so-called "banana brackets") instead of `[` and `]` for a list or `(` and `)` for a tuple.
 
 Lazy lists use the same machinery as iterator chaining to make themselves lazy, and thus the lazy list `(| x, y |)` is equivalent to the iterator chaining expression `(x,) :: (y,)`, although the lazy list won't construct the intermediate tuples.
 

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -419,12 +419,12 @@ def tokenlist(item, sep, suppress=True):
 
 
 def itemlist(item, sep, suppress_trailing=True):
-    """Create a list of items seperated by seps."""
+    """Create a list of items separated by seps."""
     return condense(item + ZeroOrMore(addspace(sep + item)) + Optional(sep.suppress() if suppress_trailing else sep))
 
 
 def exprlist(expr, op):
-    """Create a list of exprs seperated by ops."""
+    """Create a list of exprs separated by ops."""
     return addspace(expr + ZeroOrMore(op + expr))
 
 


### PR DESCRIPTION
There is a small typo in DOCS.md, coconut/compiler/util.py.

Should read `separated` rather than `seperated`.

