### PR TITLE
[fix] Error on non-numeric patch version

### DIFF
--- a/coconut/requirements.py
+++ b/coconut/requirements.py
@@ -40,7 +40,7 @@ from coconut.constants import (
 
 try:
     import setuptools  # this import is expensive, so we keep it out of constants
-    setuptools_version = tuple(int(x) for x in setuptools.__version__.split("."))
+    setuptools_version = tuple(int(x) for x in setuptools.__version__.split(".")[:2])
     using_modern_setuptools = setuptools_version >= (18,)
     supports_env_markers = setuptools_version >= (36, 2)
 except Exception:


### PR DESCRIPTION
On some build systems (such as `nix-unstable`) there is a 4th non-numeric patch
version such as `47.3.1.post20201006` that causes this version extraction to
fail. Since the code only requires the numeric part the extraction is limited to
the `major.minor` part of `major.minor.patch.patch-date`.