### PR TITLE
Remove _dummy_thread

### DIFF
--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -521,7 +521,6 @@ py3_to_py2_stdlib = {
     "configparser": ("ConfigParser", (3,)),
     "copyreg": ("copy_reg", (3,)),
     "dbm.gnu": ("gdbm", (3,)),
-    "_dummy_thread": ("dummy_thread", (3,)),
     "queue": ("Queue", (3,)),
     "reprlib": ("repr", (3,)),
     "socketserver": ("SocketServer", (3,)),


### PR DESCRIPTION
Is [deprecated](https://docs.python.org/3/library/_dummy_thread.html) and removed in 3.9.

This makes `test_imports` fails on most distributions.

```bash
============================= test session starts ==============================
platform linux -- Python 3.9.1, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /build/source
collected 4 items                                                              

tests/constants_test.py .F                                               [ 50%]
tests/main_test.py ..                                                    [100%]

=================================== FAILURES ===================================
__________________________ TestConstants.test_imports __________________________

self = <tests.constants_test.TestConstants testMethod=test_imports>

    def test_imports(self):
        for new_imp, (old_imp, ver_cutoff) in constants.py3_to_py2_stdlib.items():
            if "/" in old_imp:
                new_imp, old_imp = new_imp.split(".", 1)[0], old_imp.split("./", 1)[0]
            if (
                # don't test unix-specific dbm.gnu on Windows or PyPy
                new_imp == "dbm.gnu" and (WINDOWS or PYPY)
                # don't test ttk on Python 2.6
                or PY26 and old_imp == "ttk"
                # don't test tkinter on PyPy
                or PYPY and new_imp.startswith("tkinter")
            ):
                pass
            elif sys.version_info >= ver_cutoff:
>               assert is_importable(new_imp), "Failed to import " + new_imp
E               AssertionError: Failed to import _dummy_thread
E               assert False
E                +  where False = is_importable('_dummy_thread')

tests/constants_test.py:97: AssertionError
=========================== short test summary info ============================
FAILED tests/constants_test.py::TestConstants::test_imports - AssertionError:...
========================= 1 failed, 3 passed in 3.99s ==========================
```