### PR TITLE
Issue #587  Add --and for doing extra compilation with the same arguments

### DIFF
--- a/coconut/command/cli.py
+++ b/coconut/command/cli.py
@@ -68,6 +68,14 @@ arguments.add_argument(
 )
 
 arguments.add_argument(
+    "--and",
+    metavar=("source", "dest"),
+    nargs=2,
+    action='append',
+    help="additional source/dest pairs for compiling files",
+)
+
+arguments.add_argument(
     "-v", "-V", "--version",
     action="version",
     version=cli_version_str,

--- a/coconut/command/command.py
+++ b/coconut/command/command.py
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------------------------------------------------
 
 """
-Authors: Evan Hubinger, Fred Buchanan
+Authors: Evan Hubinger, Fred Buchanan, Noah Lipsyc
 License: Apache 2.0
 Description: The Coconut command-line utility.
 """

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -55,6 +55,7 @@ MYPY = PY34 and not WINDOWS and not PYPY
 base = os.path.dirname(os.path.relpath(__file__))
 src = os.path.join(base, "src")
 dest = os.path.join(base, "dest")
+additional_dest = os.path.join(base, "dest", "additional_dest")
 
 runnable_coco = os.path.join(src, "runnable.coco")
 runnable_py = os.path.join(src, "runnable.py")
@@ -219,6 +220,10 @@ def comp(path=None, folder=None, file=None, args=[], **kwargs):
     if file is not None:
         paths.append(file)
     source = os.path.join(src, *paths)
+    if '--and' in args:
+        additional_compdest = os.path.join(additional_dest, *paths)
+        args.remove('--and')
+        args = ['--and', source, additional_compdest] + args
     call_coconut([source, compdest] + args, **kwargs)
 
 
@@ -513,6 +518,10 @@ class TestCompilation(unittest.TestCase):
 
     def test_normal(self):
         run()
+
+    def test_multiple_source(self):
+        # --and's source and dest are built by comp() but required in normal use
+        run(['--and'])
 
     if MYPY:
         def test_universal_mypy_snip(self):


### PR DESCRIPTION
This add the option to include `--and additional/src additional/dest` to the CLI arguments.  It works under the assumption that other flags that are passed should apply to all source/dest pairs.

In addition to the automated test, I did some manual testing.  It confirmed that compiling multiples of the same file to different destinations, and multiples of different files to the same destination worked as expected. This was both with overlapping and non-overlapping names. This was tested with up to 2 `--and` pairs.