### PR TITLE
Inherit superclass' magic methods

### DIFF
--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -1889,13 +1889,21 @@ def __new__(_coconut_cls, {all_args}):
             '''
 __slots__ = ()
 __ne__ = _coconut.object.__ne__
+            ''',
+            add_newline=True,
+        )
+
+        if not inherit:
+            all_extra_stmts += handle_indentation(
+                '''
 def __eq__(self, other):
     return self.__class__ is other.__class__ and _coconut.tuple.__eq__(self, other)
 def __hash__(self):
     return _coconut.tuple.__hash__(self) ^ hash(self.__class__)
-            ''',
-            add_newline=True,
-        )
+                ''',
+                add_newline=True,
+            )
+
         if self.target_info < (3, 10):
             all_extra_stmts += "__match_args__ = " + tuple_str_of(match_args, add_quotes=True) + "\n"
         all_extra_stmts += extra_stmts

--- a/tests/src/cocotest/agnostic/suite.coco
+++ b/tests/src/cocotest/agnostic/suite.coco
@@ -696,6 +696,8 @@ def suite_test() -> bool:
     assert must_be_int(4) == 4 == must_be_int_(4)
     assert typed_plus(1, 2) == 3
     class inh_A() `isinstance` A `isinstance` object = inh_A()
+    inh_e = inh_E()
+    assert (inh_e == inh_e) == "FOO"
 
     # must come at end
     assert fibs_calls[0] == 1

--- a/tests/src/cocotest/agnostic/util.coco
+++ b/tests/src/cocotest/agnostic/util.coco
@@ -625,6 +625,9 @@ class C:
     c = 3
 class D:
     d = 4
+data E:
+    def __eq__(self, other) = "FOO"
+data inh_E from E
 
 # Nesting:
 class Nest:


### PR DESCRIPTION
**Issue**

Currently, the `__eq__` and `__hash__` methods of a data subclass are always reset, overriding any custom `__eq__`/`__hash__` magic methods of its superclass. This is inconsistent with the way Python handles subclass (magic) methods.

**Reproduce**

The following script reproduces the issue:

```python
# test.coco

data Animal:
  def __str__(self) = "MOO"
  def __eq__(self, other) = "FOO"

data Cow from Animal

a = Cow()
b = Cow()

assert str(a) == "MOO"  # OK: This returns "MOO"
assert (a == b) == "FOO"  # NOT OK: This returns True
```

**Fix**

This commit fixes the issue by only specifying `__eq__` and `__hash__` if a data class does not inherit.