### PR TITLE
Fix typo in pure-Python example for scan()

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3839,7 +3839,7 @@ max_so_far = input_data[0]
 for x in input_data:
     if x > max_so_far:
         max_so_far = x
-    running_max.append(x)
+    running_max.append(max_so_far)
 ```
 
 #### `count`


### PR DESCRIPTION
The example as written for the pure-Python equivalent of scan() acts as a pass-through operator; this is due to a typo in the code, where `x` is appended to the output instead of `max_so_far`, as the actual behaviour of `scan` would require