### PR TITLE
Release v3.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         args:
         - --autofix
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         args:

--- a/DOCS.md
+++ b/DOCS.md
@@ -1204,6 +1204,7 @@ base_pattern ::= (
     | NAME "(" patterns ")"          # classes or data types
     | "data" NAME "(" patterns ")"   # data types
     | "class" NAME "(" patterns ")"  # classes
+    | "(" name "=" pattern ... ")"   # anonymous named tuples
     | "{" pattern_pairs              # dictionaries
         ["," "**" (NAME | "{}")] "}" #  (keys must be constants or equality checks)
     | ["s" | "f" | "m"] "{"
@@ -1269,7 +1270,8 @@ base_pattern ::= (
   - Classes or Data Types (`<name>(<args>)`): will match as a data type if given [a Coconut `data` type](#data) (or a tuple of Coconut data types) and a class otherwise.
   - Data Types (`data <name>(<args>)`): will check that whatever is in that position is of data type `<name>` and will match the attributes to `<args>`. Generally, `data <name>(<args>)` will match any data type that could have been constructed with `makedata(<name>, <args>)`. Includes support for positional arguments, named arguments, default arguments, and starred arguments. Also supports strict attributes by prepending a dot to the attribute name that raises `AttributError` if the attribute is not present rather than failing the match (e.g. `data MyData(.my_attr=<some_pattern>)`).
   - Classes (`class <name>(<args>)`): does [PEP-634-style class matching](https://www.python.org/dev/peps/pep-0634/#class-patterns). Also supports strict attribute matching as above.
-- Mapping Destructuring:
+  - Anonymous Named Tuples (`(<name>=<pattern>, ...)`): checks that the object is a `tuple` of the given length with the given attributes. For matching [anonymous `namedtuple`s](#anonymous-namedtuples).
+- Dict Destructuring:
   - Dicts (`{<key>: <value>, ...}`): will match any mapping (`collections.abc.Mapping`) with the given keys and values that match the value patterns. Keys must be constants or equality checks.
   - Dicts With Rest (`{<pairs>, **<rest>}`): will match a mapping (`collections.abc.Mapping`) containing all the `<pairs>`, and will put a `dict` of everything else into `<rest>`. If `<rest>` is `{}`, will enforce that the mapping is exactly the same length as `<pairs>`.
 - Set Destructuring:
@@ -2233,7 +2235,7 @@ as a shorthand for
 f(long_variable_name=long_variable_name)
 ```
 
-Such syntax is also supported in [partial application](#partial-application) and [anonymous `namedtuple`s](#anonymous-namedtuples).
+Such syntax is also supported in [partial application](#partial-application), [anonymous `namedtuple`s](#anonymous-namedtuples), and [`class`/`data`/anonymous `namedtuple` patterns](#match).
 
 _Deprecated: Coconut also supports `f(...=long_variable_name)` as an alternative shorthand syntax._
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -1737,7 +1737,7 @@ The syntax for a statement lambda is
 ```
 [async|match|copyclosure] def (arguments) => statement; statement; ...
 ```
-where `arguments` can be standard function arguments or [pattern-matching function definition](#pattern-matching-functions) arguments and `statement` can be an assignment statement or a keyword statement. Note that the `async`, `match`, and [`copyclosure`](#copyclosure-functions) keywords can be combined and can be in any order.
+where `arguments` can be standard function arguments or [pattern-matching function definition](#pattern-matching-functions) arguments and `statement` can be any non-compound statement—that is, any statement that doesn't open a code block below it (so `def x => assert x` is fine but `def x => if x: True` is not). Note that the `async`, `match`, and [`copyclosure`](#copyclosure-functions) keywords can be combined and can be in any order.
 
 If the last `statement` (not followed by a semicolon) in a statement lambda is an `expression`, it will automatically be returned.
 
@@ -3805,9 +3805,9 @@ _Can’t be done quickly without Coconut’s iterable indexing, which requires m
 
 #### `reduce`
 
-**reduce**(_function_, _iterable_[, _initial_], /)
+**reduce**(_function_, _iterable_[, _initial_])
 
-Coconut re-introduces Python 2's `reduce` built-in, using the `functools.reduce` version.
+Coconut re-introduces Python 2's `reduce` built-in, using the `functools.reduce` version. Additionally, unlike `functools.reduce`, Coconut's `reduce` always supports keyword arguments.
 
 ##### Python Docs
 
@@ -3937,9 +3937,9 @@ result = itertools.zip_longest(range(5), range(10))
 
 #### `takewhile`
 
-**takewhile**(_predicate_, _iterable_, /)
+**takewhile**(_predicate_, _iterable_)
 
-Coconut provides `itertools.takewhile` as a built-in under the name `takewhile`.
+Coconut provides `itertools.takewhile` as a built-in under the name `takewhile`. Additionally, unlike `itertools.takewhile`, Coconut's `takewhile` always supports keyword arguments.
 
 ##### Python Docs
 
@@ -3971,9 +3971,9 @@ negatives = itertools.takewhile(lambda x: x < 0, numiter)
 
 #### `dropwhile`
 
-**dropwhile**(_predicate_, _iterable_, /)
+**dropwhile**(_predicate_, _iterable_)
 
-Coconut provides `itertools.dropwhile` as a built-in under the name `dropwhile`.
+Coconut provides `itertools.dropwhile` as a built-in under the name `dropwhile`. Additionally, unlike `itertools.dropwhile`, Coconut's `dropwhile` always supports keyword arguments.
 
 ##### Python Docs
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -2264,7 +2264,7 @@ main_func(
 
 ### Anonymous Namedtuples
 
-Coconut supports anonymous [`namedtuple`](https://docs.python.org/3/library/collections.html#collections.namedtuple) literals, such that `(a=1, b=2)` can be used just as `(1, 2)`, but with added names. Anonymous `namedtuple`s are always pickleable.
+Coconut supports anonymous [`namedtuple`](https://docs.python.org/3/library/collections.html#collections.namedtuple) literals, such that `(a=1, b=2)` can be used just as `(1, 2)`, but with added names. Anonymous `namedtuple`s are always pickleable and support [`__match_args__`](https://peps.python.org/pep-0622/) on all Python versions.
 
 The syntax for anonymous namedtuple literals is:
 ```coconut

--- a/Makefile
+++ b/Makefile
@@ -26,27 +26,27 @@ dev-py3: clean setup-py3
 .PHONY: setup
 setup:
 	-python -m ensurepip
-	python -m pip install --upgrade setuptools wheel pip pytest_remotedata cython
+	python -m pip install --upgrade setuptools wheel pip cython
 
 .PHONY: setup-py2
 setup-py2:
 	-python2 -m ensurepip
-	python2 -m pip install --upgrade "setuptools<58" wheel pip pytest_remotedata cython
+	python2 -m pip install --upgrade "setuptools<58" wheel pip cython
 
 .PHONY: setup-py3
 setup-py3:
 	-python3 -m ensurepip
-	python3 -m pip install --upgrade setuptools wheel pip pytest_remotedata cython
+	python3 -m pip install --upgrade setuptools wheel pip cython
 
 .PHONY: setup-pypy
 setup-pypy:
 	-pypy -m ensurepip
-	pypy -m pip install --upgrade "setuptools<58" wheel pip pytest_remotedata
+	pypy -m pip install --upgrade "setuptools<58" wheel pip
 
 .PHONY: setup-pypy3
 setup-pypy3:
 	-pypy3 -m ensurepip
-	pypy3 -m pip install --upgrade setuptools wheel pip pytest_remotedata
+	pypy3 -m pip install --upgrade setuptools wheel pip
 
 .PHONY: install
 install: setup

--- a/__coconut__/__init__.pyi
+++ b/__coconut__/__init__.pyi
@@ -1865,6 +1865,18 @@ def _coconut_mk_anon_namedtuple(
     fields: _t.Tuple[_t.Text, ...],
     types: _t.Optional[_t.Tuple[_t.Any, ...]] = None,
 ) -> _t.Callable[..., _t.Tuple[_t.Any, ...]]: ...
+@_t.overload
+def _coconut_mk_anon_namedtuple(
+    fields: _t.Tuple[_t.Text, ...],
+    types: _t.Optional[_t.Tuple[_t.Any, ...]],
+    of_args: _T,
+) -> _T: ...
+@_t.overload
+def _coconut_mk_anon_namedtuple(
+    fields: _t.Tuple[_t.Text, ...],
+    *,
+    of_args: _T,
+) -> _T: ...
 
 
 # @_t.overload

--- a/coconut/_pyparsing.py
+++ b/coconut/_pyparsing.py
@@ -46,7 +46,7 @@ from coconut.constants import (
     never_clear_incremental_cache,
     warn_on_multiline_regex,
     num_displayed_timing_items,
-    use_cache_file,
+    use_pyparsing_cache_file,
     use_line_by_line_parser,
     incremental_use_hybrid,
 )
@@ -254,7 +254,7 @@ SUPPORTS_ADAPTIVE = (
     and hasattr(MatchFirst, "setAdaptiveMode")
 )
 
-USE_CACHE = SUPPORTS_INCREMENTAL and use_cache_file
+USE_CACHE = SUPPORTS_INCREMENTAL and use_pyparsing_cache_file
 USE_LINE_BY_LINE = USE_COMPUTATION_GRAPH and use_line_by_line_parser
 
 if MODERN_PYPARSING:

--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -671,7 +671,7 @@ class Prompt(object):
     style = None
     runner = None
     lexer = None
-    suggester = None if prompt_use_suggester else False
+    suggester = True if prompt_use_suggester else None
 
     def __init__(self, setup_now=False):
         """Set up the prompt."""
@@ -686,7 +686,7 @@ class Prompt(object):
         We do this lazily since it's expensive."""
         if self.lexer is None:
             self.lexer = PygmentsLexer(CoconutLexer)
-        if self.suggester is None:
+        if self.suggester is True:
             self.suggester = AutoSuggestFromHistory()
 
     def set_style(self, style):
@@ -760,7 +760,7 @@ class Prompt(object):
                 pygments.styles.get_style_by_name(self.style),
             ),
             completer=self.get_completer(),
-            auto_suggest=self.suggester or None,
+            auto_suggest=self.suggester,
         )
 
 

--- a/coconut/command/util.py
+++ b/coconut/command/util.py
@@ -760,7 +760,7 @@ class Prompt(object):
                 pygments.styles.get_style_by_name(self.style),
             ),
             completer=self.get_completer(),
-            auto_suggest=self.suggester,
+            auto_suggest=self.suggester or None,
         )
 
 

--- a/coconut/compiler/compiler.py
+++ b/coconut/compiler/compiler.py
@@ -4575,7 +4575,7 @@ async with {iter_item} as {temp_var}:
             return tokens[0]
         else:
             if not allow_silent_concat:
-                self.strict_err_or_warn("found Python-style implicit string concatenation (use explicit '+' instead)", original, loc)
+                self.strict_err_or_warn("found implicit string concatenation (use explicit '+' instead)", original, loc)
             if any(s.endswith(")") for s in tokens):  # has .format() calls
                 # parens are necessary for string_atom_handle
                 return "(" + " + ".join(tokens) + ")"

--- a/coconut/compiler/header.py
+++ b/coconut/compiler/header.py
@@ -458,6 +458,14 @@ raise _coconut.RuntimeError("_namedtuple_of is not available on Python < 3.6 (us
             ''',
             indent=1,
         ),
+        set_nt_match_args=pycondition(
+            (3, 10),
+            if_lt=r'''
+nt.__match_args__ = nt._fields
+            ''',
+            indent=1,
+            newline=True,
+        ),
         import_copyreg=pycondition(
             (3,),
             if_lt="import copy_reg as copyreg",

--- a/coconut/compiler/header.py
+++ b/coconut/compiler/header.py
@@ -458,10 +458,10 @@ raise _coconut.RuntimeError("_namedtuple_of is not available on Python < 3.6 (us
             ''',
             indent=1,
         ),
-        set_nt_match_args=pycondition(
+        set_NT_match_args=pycondition(
             (3, 10),
             if_lt=r'''
-nt.__match_args__ = nt._fields
+NT.__match_args__ = _coconut.property(lambda self: self._fields)
             ''',
             indent=1,
             newline=True,

--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -62,7 +62,7 @@ class _coconut{object}:{COMMENT.EVERYTHING_HERE_MUST_BE_COPIED_TO_STUB_FILE}
     fmappables = list, tuple, dict, set, frozenset, bytes, bytearray
     abc.Sequence.register(collections.deque)
     Ellipsis, NotImplemented, NotImplementedError, Exception, AttributeError, ImportError, IndexError, KeyError, NameError, TypeError, ValueError, StopIteration, RuntimeError, all, any, bool, bytes, callable, chr, classmethod, complex, dict, enumerate, filter, float, frozenset, getattr, hasattr, hash, id, int, isinstance, issubclass, iter, len, list, locals, globals, map, min, max, next, object, ord, property, range, reversed, set, setattr, slice, str, sum, super, tuple, type, vars, zip, repr, print{comma_bytearray} = Ellipsis, NotImplemented, NotImplementedError, Exception, AttributeError, ImportError, IndexError, KeyError, NameError, TypeError, ValueError, StopIteration, RuntimeError, all, any, bool, bytes, callable, chr, classmethod, complex, dict, enumerate, filter, float, frozenset, getattr, hasattr, hash, id, int, isinstance, issubclass, iter, len, list, locals, globals, map, {lstatic}min{rstatic}, {lstatic}max{rstatic}, next, object, ord, property, range, reversed, set, setattr, slice, str, sum, {lstatic}super{rstatic}, tuple, type, vars, zip, {lstatic}repr{rstatic}, {lstatic}print{rstatic}{comma_bytearray}
-@_coconut.functools.wraps(_coconut.functools.partial)
+@_coconut_wraps(_coconut.functools.partial)
 def _coconut_partial(_coconut_func, *args, **kwargs):
     partial_func = _coconut.functools.partial(_coconut_func, *args, **kwargs)
     partial_func.__name__ = _coconut.getattr(_coconut_func, "__name__", None)
@@ -182,7 +182,7 @@ class _coconut_tail_call(_coconut_baseclass):
         return (self.__class__, (self.func, self.args, self.kwargs))
 _coconut_tco_func_dict = _coconut.weakref.WeakValueDictionary()
 def _coconut_tco(func):
-    @_coconut.functools.wraps(func)
+    @_coconut_wraps(func)
     def tail_call_optimized_func(*args, **kwargs):
         call_func = func
         while True:{COMMENT.weakrefs_necessary_for_ignoring_functools_wraps_decorators}
@@ -209,7 +209,7 @@ def _coconut_tco(func):
     tail_call_optimized_func.__qualname__ = _coconut.getattr(func, "__qualname__", None)
     _coconut_tco_func_dict[_coconut.id(tail_call_optimized_func)] = tail_call_optimized_func
     return tail_call_optimized_func
-@_coconut.functools.wraps(_coconut.itertools.tee)
+@_coconut_wraps(_coconut.itertools.tee)
 def tee(iterable, n=2):
     if n < 0:
         raise _coconut.ValueError("tee: n cannot be negative")
@@ -2220,7 +2220,22 @@ class _coconut_SupportsInv(_coconut.typing.Protocol):
     """
     def __invert__(self):
         raise _coconut.NotImplementedError("Protocol methods cannot be called at runtime ((~) in a typing context is a Protocol)")
+@_coconut_wraps(_coconut.functools.reduce)
+def reduce(function, iterable, initial=_coconut_sentinel):
+    if initial is _coconut_sentinel:
+        return _coconut.functools.reduce(function, iterable)
+    return _coconut.functools.reduce(function, iterable, initial)
+class takewhile(_coconut.itertools.takewhile{comma_object}):
+    __slots__ = ()
+    __doc__ = _coconut.itertools.takewhile.__doc__
+    def __new__(cls, predicate, iterable):
+        return _coconut.itertools.takewhile.__new__(cls, predicate, iterable)
+class dropwhile(_coconut.itertools.dropwhile{comma_object}):
+    __slots__ = ()
+    __doc__ = _coconut.itertools.dropwhile.__doc__
+    def __new__(cls, predicate, iterable):
+        return _coconut.itertools.dropwhile.__new__(cls, predicate, iterable)
 {def_async_map}
 {def_aliases}
 _coconut_self_match_types = {self_match_types}
-_coconut_Expected, _coconut_MatchError, _coconut_cartesian_product, _coconut_count, _coconut_cycle, _coconut_enumerate, _coconut_flatten, _coconut_fmap, _coconut_filter, _coconut_groupsof, _coconut_ident, _coconut_lift, _coconut_map, _coconut_mapreduce, _coconut_multiset, _coconut_range, _coconut_reiterable, _coconut_reversed, _coconut_scan, _coconut_starmap, _coconut_tee, _coconut_windowsof, _coconut_zip, _coconut_zip_longest, TYPE_CHECKING, reduce, takewhile, dropwhile = Expected, MatchError, cartesian_product, count, cycle, enumerate, flatten, fmap, filter, groupsof, ident, lift, map, mapreduce, multiset, range, reiterable, reversed, scan, starmap, tee, windowsof, zip, zip_longest, False, _coconut.functools.reduce, _coconut.itertools.takewhile, _coconut.itertools.dropwhile{COMMENT.anything_added_here_should_be_copied_to_stub_file}
+TYPE_CHECKING, _coconut_Expected, _coconut_MatchError, _coconut_cartesian_product, _coconut_count, _coconut_cycle, _coconut_enumerate, _coconut_flatten, _coconut_fmap, _coconut_filter, _coconut_groupsof, _coconut_ident, _coconut_lift, _coconut_map, _coconut_mapreduce, _coconut_multiset, _coconut_range, _coconut_reiterable, _coconut_reversed, _coconut_scan, _coconut_starmap, _coconut_tee, _coconut_windowsof, _coconut_zip, _coconut_zip_longest = False, Expected, MatchError, cartesian_product, count, cycle, enumerate, flatten, fmap, filter, groupsof, ident, lift, map, mapreduce, multiset, range, reiterable, reversed, scan, starmap, tee, windowsof, zip, zip_longest{COMMENT.anything_added_here_should_be_copied_to_stub_file}

--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -2024,8 +2024,10 @@ def _coconut_mk_anon_namedtuple(fields, types=None, of_kwargs=None):
         NT = _coconut.typing.NamedTuple("_namedtuple_of", [(f, t) for f, t in _coconut.zip(fields, types)])
     _coconut.copyreg.pickle(NT, lambda nt: (_coconut_mk_anon_namedtuple, (nt._fields, types, nt._asdict())))
     if of_kwargs is None:
-        return NT
-    return NT(**of_kwargs)
+        nt = NT
+    else:
+        nt = NT(**of_kwargs)
+{set_nt_match_args}    return nt
 def _coconut_ndim(arr):
     arr_mod = _coconut_get_base_module(arr)
     if (arr_mod in _coconut.numpy_modules or _coconut.hasattr(arr.__class__, "__matconcat__")) and _coconut.hasattr(arr, "ndim"):

--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -2017,17 +2017,17 @@ collectby.using_threads = _coconut_partial(_coconut_parallel_mapreduce, collectb
 def _namedtuple_of(**kwargs):
     """Construct an anonymous namedtuple of the given keyword arguments."""
 {namedtuple_of_implementation}
-def _coconut_mk_anon_namedtuple(fields, types=None, of_kwargs=None):
+def _coconut_mk_anon_namedtuple(fields, types=None, of_kwargs={empty_dict}, of_args=()):
     if types is None:
         NT = _coconut.collections.namedtuple("_namedtuple_of", fields)
     else:
         NT = _coconut.typing.NamedTuple("_namedtuple_of", [(f, t) for f, t in _coconut.zip(fields, types)])
     _coconut.copyreg.pickle(NT, lambda nt: (_coconut_mk_anon_namedtuple, (nt._fields, types, nt._asdict())))
-    if of_kwargs is None:
-        nt = NT
-    else:
-        nt = NT(**of_kwargs)
-{set_nt_match_args}    return nt
+    if not (of_kwargs or of_args):
+        return NT
+    nt = NT(*of_args, **of_kwargs)
+{set_nt_match_args}
+    return nt
 def _coconut_ndim(arr):
     arr_mod = _coconut_get_base_module(arr)
     if (arr_mod in _coconut.numpy_modules or _coconut.hasattr(arr.__class__, "__matconcat__")) and _coconut.hasattr(arr, "ndim"):

--- a/coconut/compiler/templates/header.py_template
+++ b/coconut/compiler/templates/header.py_template
@@ -2023,11 +2023,10 @@ def _coconut_mk_anon_namedtuple(fields, types=None, of_kwargs={empty_dict}, of_a
     else:
         NT = _coconut.typing.NamedTuple("_namedtuple_of", [(f, t) for f, t in _coconut.zip(fields, types)])
     _coconut.copyreg.pickle(NT, lambda nt: (_coconut_mk_anon_namedtuple, (nt._fields, types, nt._asdict())))
-    if not (of_kwargs or of_args):
+{set_NT_match_args}    if of_kwargs or of_args:
+        return NT(*of_args, **of_kwargs)
+    else:
         return NT
-    nt = NT(*of_args, **of_kwargs)
-{set_nt_match_args}
-    return nt
 def _coconut_ndim(arr):
     arr_mod = _coconut_get_base_module(arr)
     if (arr_mod in _coconut.numpy_modules or _coconut.hasattr(arr.__class__, "__matconcat__")) and _coconut.hasattr(arr, "ndim"):

--- a/coconut/compiler/util.py
+++ b/coconut/compiler/util.py
@@ -1925,6 +1925,12 @@ def rem_comment(line):
     return base
 
 
+def get_comment(line):
+    """Extract a comment from a line if it has one."""
+    base, comment = split_comment(line)
+    return comment
+
+
 def should_indent(code):
     """Determines whether the next line should be indented."""
     last_line = rem_comment(code.splitlines()[-1])

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -638,7 +638,7 @@ main_sig = "Coconut: "
 main_prompt = ">>> "
 more_prompt = "    "
 
-default_use_cache_dir = get_bool_env_var("COCONUT_USE_COCONUT_CACHE", PY34)
+default_use_cache_dir = get_bool_env_var("COCONUT_USE_CACHE_DIR", PY34)
 coconut_cache_dir = "__coconut_cache__"
 
 mypy_path_env_var = "MYPYPATH"

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -666,7 +666,7 @@ prompt_multiline = False
 prompt_vi_mode = get_bool_env_var(vi_mode_env_var, False)
 prompt_wrap_lines = True
 prompt_history_search = True
-prompt_use_suggester = not PY2
+prompt_use_suggester = False
 
 base_dir = os.path.dirname(os.path.abspath(fixpath(__file__)))
 

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -607,15 +607,20 @@ python_builtins = (
     "tuple", "type",
     "vars",
     "zip",
+    'Ellipsis',
     "__import__",
     '__name__',
     '__file__',
     '__annotations__',
     '__debug__',
+    '__build_class__',
+    '__loader__',
+    '__package__',
+    '__spec__',
 )
 
 python_exceptions = (
-    "BaseException", "BaseExceptionGroup", "GeneratorExit", "KeyboardInterrupt", "SystemExit", "Exception", "ArithmeticError", "FloatingPointError", "OverflowError", "ZeroDivisionError", "AssertionError", "AttributeError", "BufferError", "EOFError", "ExceptionGroup", "BaseExceptionGroup", "ImportError", "ModuleNotFoundError", "LookupError", "IndexError", "KeyError", "MemoryError", "NameError", "UnboundLocalError", "OSError", "BlockingIOError", "ChildProcessError", "ConnectionError", "BrokenPipeError", "ConnectionAbortedError", "ConnectionRefusedError", "ConnectionResetError", "FileExistsError", "FileNotFoundError", "InterruptedError", "IsADirectoryError", "NotADirectoryError", "PermissionError", "ProcessLookupError", "TimeoutError", "ReferenceError", "RuntimeError", "NotImplementedError", "RecursionError", "StopAsyncIteration", "StopIteration", "SyntaxError", "IndentationError", "TabError", "SystemError", "TypeError", "ValueError", "UnicodeError", "UnicodeDecodeError", "UnicodeEncodeError", "UnicodeTranslateError", "Warning", "BytesWarning", "DeprecationWarning", "EncodingWarning", "FutureWarning", "ImportWarning", "PendingDeprecationWarning", "ResourceWarning", "RuntimeWarning", "SyntaxWarning", "UnicodeWarning", "UserWarning",
+    'ArithmeticError', 'AssertionError', 'AttributeError', 'BaseException', 'BaseExceptionGroup', 'BlockingIOError', 'BrokenPipeError', 'BufferError', 'BytesWarning', 'ChildProcessError', 'ConnectionAbortedError', 'ConnectionError', 'ConnectionRefusedError', 'ConnectionResetError', 'DeprecationWarning', 'EOFError', 'EncodingWarning', 'EnvironmentError', 'Exception', 'ExceptionGroup', 'FileExistsError', 'FileNotFoundError', 'FloatingPointError', 'FutureWarning', 'GeneratorExit', 'IOError', 'ImportError', 'ImportWarning', 'IndentationError', 'IndexError', 'InterruptedError', 'IsADirectoryError', 'KeyError', 'KeyboardInterrupt', 'LookupError', 'MemoryError', 'ModuleNotFoundError', 'NameError', 'NotADirectoryError', 'NotImplemented', 'NotImplementedError', 'OSError', 'OverflowError', 'PendingDeprecationWarning', 'PermissionError', 'ProcessLookupError', 'RecursionError', 'ReferenceError', 'ResourceWarning', 'RuntimeError', 'RuntimeWarning', 'StopAsyncIteration', 'StopIteration', 'SyntaxError', 'SyntaxWarning', 'SystemError', 'SystemExit', 'TabError', 'TimeoutError', 'TypeError', 'UnboundLocalError', 'UnicodeDecodeError', 'UnicodeEncodeError', 'UnicodeError', 'UnicodeTranslateError', 'UnicodeWarning', 'UserWarning', 'ValueError', 'Warning', 'WindowsError', 'ZeroDivisionError'
 )
 
 always_keep_parse_name_prefix = "HAS_"

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -1056,7 +1056,6 @@ unpinned_min_versions = {
     "pexpect": (4,),
     ("trollius", "py<3;cpy"): (2, 2),
     "requests": (2, 32),
-    ("numpy", "py39"): (2,),
     ("xarray", "py39"): (2024,),
     ("dataclasses", "py==36"): (0, 8),
     ("aenum", "py<34"): (3, 1, 15),
@@ -1082,6 +1081,8 @@ unpinned_min_versions = {
 }
 
 pinned_min_versions = {
+    # don't upgrade this; some extensions implicitly require numpy<2
+    ("numpy", "py39"): (1, 26),
     # don't upgrade this; it breaks xonsh
     ("pytest", "py38"): (8, 0),
     # don't upgrade these; they break on Python 3.9

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -101,6 +101,10 @@ XONSH = (
     and not (PYPY and PY39)
     and (PY38 or not PY36)
 )
+NUMPY = (
+    not PYPY
+    and (PY2 or PY34)
+)
 
 py_version_str = sys.version.split()[0]
 

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -666,7 +666,7 @@ prompt_multiline = False
 prompt_vi_mode = get_bool_env_var(vi_mode_env_var, False)
 prompt_wrap_lines = True
 prompt_history_search = True
-prompt_use_suggester = False
+prompt_use_suggester = not PY2
 
 base_dir = os.path.dirname(os.path.abspath(fixpath(__file__)))
 

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -135,7 +135,7 @@ packrat_cache_size = None  # only works because final() clears the cache
 
 streamline_grammar_for_len = 1536
 
-use_cache_file = True
+use_pyparsing_cache_file = True
 
 adaptive_any_of_env_var = "COCONUT_ADAPTIVE_ANY_OF"
 use_adaptive_any_of = get_bool_env_var(adaptive_any_of_env_var, True)
@@ -638,7 +638,7 @@ main_sig = "Coconut: "
 main_prompt = ">>> "
 more_prompt = "    "
 
-default_use_cache_dir = PY34
+default_use_cache_dir = get_bool_env_var("COCONUT_USE_COCONUT_CACHE", PY34)
 coconut_cache_dir = "__coconut_cache__"
 
 mypy_path_env_var = "MYPYPATH"

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -1024,6 +1024,9 @@ all_reqs = {
         ("pygments", "py>=39"),
         "myst-parser",
         "pydata-sphinx-theme",
+        # these are necessary to fix a sphinx error
+        "sphinxcontrib_applehelp",
+        "sphinxcontrib_htmlhelp",
     ),
     "numpy": (
         ("numpy", "py<3;cpy"),
@@ -1037,6 +1040,7 @@ all_reqs = {
         ("pytest", "py>=36;py<38"),
         ("pytest", "py38"),
         "pexpect",
+        "pytest_remotedata",  # fixes a pytest error
     ),
 }
 
@@ -1044,22 +1048,24 @@ all_reqs = {
 unpinned_min_versions = {
     "cPyparsing": (2, 4, 7, 2, 4, 0),
     ("pre-commit", "py3"): (3,),
-    ("psutil", "py>=27"): (5,),
-    "jupyter": (1, 0),
+    ("psutil", "py>=27"): (6,),
+    "jupyter": (1, 1),
     "types-backports": (0, 1),
     ("futures", "py<3"): (3, 4),
     ("argparse", "py<27"): (1, 4),
     "pexpect": (4,),
     ("trollius", "py<3;cpy"): (2, 2),
     "requests": (2, 32),
-    ("numpy", "py39"): (1, 26),
+    ("numpy", "py39"): (2,),
     ("xarray", "py39"): (2024,),
     ("dataclasses", "py==36"): (0, 8),
     ("aenum", "py<34"): (3, 1, 15),
     "pydata-sphinx-theme": (0, 15),
-    "myst-parser": (3,),
-    "sphinx": (7,),
-    "mypy[python2]": (1, 10),
+    "myst-parser": (4,),
+    "sphinx": (8,),
+    "sphinxcontrib_applehelp": (2,),
+    "sphinxcontrib_htmlhelp": (2,),
+    "mypy[python2]": (1, 11),
     "pyright": (1, 1),
     ("jupyter-console", "py37"): (6, 6),
     ("typing", "py<35"): (3, 10),
@@ -1067,11 +1073,12 @@ unpinned_min_versions = {
     ("ipykernel", "py38"): (6,),
     ("jedi", "py39"): (0, 19),
     ("pygments", "py>=39"): (2, 18),
-    ("xonsh", "py39"): (0, 16),
+    ("xonsh", "py39"): (0, 18),
     ("async_generator", "py35"): (1, 10),
     ("exceptiongroup", "py37;py<311"): (1,),
-    ("ipython", "py>=310"): (8, 25),
+    ("ipython", "py>=310"): (8, 27),
     "py-spy": (0, 3),
+    "pytest_remotedata": (0, 4),
 }
 
 pinned_min_versions = {
@@ -1088,7 +1095,7 @@ pinned_min_versions = {
     # don't upgrade these; they break on Python 3.6
     ("anyio", "py36"): (3,),
     ("xonsh", "py>=36;py<39"): (0, 11),
-    ("pandas", "py36"): (1,),
+    ("pandas", "py36"): (1, 16),
     ("jupyter-client", "py36"): (7, 1, 2),
     ("typing_extensions", "py==36"): (4, 1),
     ("pytest", "py>=36;py<38"): (7,),

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -1077,7 +1077,6 @@ unpinned_min_versions = {
     ("exceptiongroup", "py37;py<311"): (1,),
     ("ipython", "py>=310"): (8, 27),
     "py-spy": (0, 3),
-    "pytest_remotedata": (0, 4),
 }
 
 pinned_min_versions = {
@@ -1096,7 +1095,7 @@ pinned_min_versions = {
     # don't upgrade these; they break on Python 3.6
     ("anyio", "py36"): (3,),
     ("xonsh", "py>=36;py<39"): (0, 11),
-    ("pandas", "py36"): (1, 16),
+    ("pandas", "py36"): (1, 1),
     ("jupyter-client", "py36"): (7, 1, 2),
     ("typing_extensions", "py==36"): (4, 1),
     ("pytest", "py>=36;py<38"): (7,),
@@ -1129,6 +1128,7 @@ pinned_min_versions = {
     "papermill": (1, 2),
     ("numpy", "py<3;cpy"): (1, 16),
     ("backports.functools-lru-cache", "py<3"): (1, 6),
+    "pytest_remotedata": (0, 3),
     # don't upgrade this; it breaks with old IPython versions
     ("jedi", "py<39"): (0, 17),
     # Coconut requires pyparsing 2

--- a/coconut/icoconut/root.py
+++ b/coconut/icoconut/root.py
@@ -48,7 +48,7 @@ from coconut.constants import (
 from coconut.terminal import logger
 from coconut.util import override, memoize_with_exceptions, replace_all
 from coconut.compiler import Compiler
-from coconut.compiler.util import should_indent, paren_change
+from coconut.compiler.util import should_indent, paren_change, get_comment
 from coconut.command.util import Runner
 
 try:
@@ -214,7 +214,10 @@ if LOAD_MODULE:
                     level += paren_change(no_strs_line)
 
                     # put line in parts and break if done
-                    if level < 0:
+                    if get_comment(line):
+                        parts.append(line)
+                        break
+                    elif level < 0:
                         parts.append(line)
                     elif no_strs_line.endswith("\\"):
                         parts.append(line[:-1])

--- a/coconut/requirements.py
+++ b/coconut/requirements.py
@@ -25,6 +25,7 @@ from coconut.integrations import embed
 from coconut.constants import (
     CPYTHON,
     PY34,
+    NUMPY,
     IPY,
     MYPY,
     XONSH,
@@ -249,7 +250,7 @@ extras.update({
     "docs": unique_wrt(get_reqs("docs"), requirements),
     "tests": uniqueify_all(
         get_reqs("tests"),
-        extras["numpy"],
+        extras["numpy"] if NUMPY else [],
         extras["jupyter"] if IPY else [],
         extras["mypy"] if MYPY else [],
         extras["xonsh"] if XONSH else [],

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 6
+DEVELOP = 7
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 5
+DEVELOP = 6
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -23,10 +23,10 @@ import sys as _coconut_sys
 # VERSION:
 # -----------------------------------------------------------------------------------------------------------------------
 
-VERSION = "3.1.1"
+VERSION = "3.1.2"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 7
+DEVELOP = False
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 1
+DEVELOP = 2
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 2
+DEVELOP = 3
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = False
+DEVELOP = 1
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 4
+DEVELOP = 5
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -59,11 +59,23 @@ def _get_target_info(target):
 # HEADER:
 # -----------------------------------------------------------------------------------------------------------------------
 
+_base_header = r'''
+import functools as _coconut_functools
+_coconut_getattr = getattr
+def _coconut_wraps(base_func):
+    def wrap(new_func):
+        new_func_module = _coconut_getattr(new_func, "__module__")
+        _coconut_functools.update_wrapper(new_func, base_func)
+        if new_func_module is not None:
+            new_func.__module__ = new_func_module
+        return new_func
+    return wrap
+'''
+
 # if a new assignment is added below, a new builtins import should be added alongside it
 _base_py3_header = r'''from builtins import chr, dict, hex, input, int, map, object, oct, open, print, range, str, super, zip, filter, reversed, enumerate, repr
 py_bytes, py_chr, py_dict, py_hex, py_input, py_int, py_map, py_object, py_oct, py_open, py_print, py_range, py_str, py_super, py_zip, py_filter, py_reversed, py_enumerate, py_repr, py_min, py_max = bytes, chr, dict, hex, input, int, map, object, oct, open, print, range, str, super, zip, filter, reversed, enumerate, repr, min, max
 _coconut_py_str, _coconut_py_super, _coconut_py_dict, _coconut_py_min, _coconut_py_max = str, super, dict, min, max
-from functools import wraps as _coconut_wraps
 exec("_coconut_exec = exec")
 '''
 
@@ -71,7 +83,6 @@ exec("_coconut_exec = exec")
 _base_py2_header = r'''from __builtin__ import chr, dict, hex, input, int, map, object, oct, open, print, range, str, super, zip, filter, reversed, enumerate, raw_input, xrange, repr, long
 py_bytes, py_chr, py_dict, py_hex, py_input, py_int, py_map, py_object, py_oct, py_open, py_print, py_range, py_str, py_super, py_zip, py_filter, py_reversed, py_enumerate, py_raw_input, py_xrange, py_repr, py_min, py_max = bytes, chr, dict, hex, input, int, map, object, oct, open, print, range, str, super, zip, filter, reversed, enumerate, raw_input, xrange, repr, min, max
 _coconut_py_raw_input, _coconut_py_xrange, _coconut_py_int, _coconut_py_long, _coconut_py_print, _coconut_py_str, _coconut_py_super, _coconut_py_unicode, _coconut_py_repr, _coconut_py_dict, _coconut_py_bytes, _coconut_py_min, _coconut_py_max = raw_input, xrange, int, long, print, str, super, unicode, repr, dict, bytes, min, max
-from functools import wraps as _coconut_wraps
 from collections import Sequence as _coconut_Sequence
 from future_builtins import *
 chr, str = unichr, unicode
@@ -353,7 +364,7 @@ _py37_py38_extras = '''class _coconut_dict_base(_coconut_py_dict):
     __doc__ = getattr(_coconut_py_dict, "__doc__", "<see help(py_dict)>")''' + _finish_dict_def
 
 _py26_extras = '''if _coconut_sys.version_info < (2, 7):
-    import functools as _coconut_functools, copy_reg as _coconut_copy_reg
+    import copy_reg as _coconut_copy_reg
     def _coconut_new_partial(func, args, keywords):
         return _coconut_functools.partial(func, *(args if args is not None else ()), **(keywords if keywords is not None else {}))
     _coconut_copy_reg.constructor(_coconut_new_partial)
@@ -392,7 +403,7 @@ def _get_root_header(version="universal"):
 ''' + _indent(_get_root_header("3"))
 
     version_info = _get_target_info(version)
-    header = ""
+    header = _base_header
 
     if version.startswith("3"):
         header += _base_py3_header

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.1.1"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 3
+DEVELOP = 4
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/tests/main_test.py
+++ b/coconut/tests/main_test.py
@@ -1108,11 +1108,12 @@ if TEST_ALL:
         #         if PY38:
         #             run_pyprover()
 
-        def test_pyston(self):
-            with using_paths(pyston):
-                comp_pyston(["--no-tco"])
-                if PYPY and PY2:
-                    run_pyston()
+        if PY312:  # reduce test load
+            def test_pyston(self):
+                with using_paths(pyston):
+                    comp_pyston(["--no-tco"])
+                    if PYPY and PY2:
+                        run_pyston()
 
 
 # -----------------------------------------------------------------------------------------------------------------------

--- a/coconut/tests/main_test.py
+++ b/coconut/tests/main_test.py
@@ -1054,11 +1054,8 @@ class TestCompilation(unittest.TestCase):
                 }):
                     run()
 
-        def test_keep_lines(self):
-            run(["--keep-lines"])
-
-        def test_strict(self):
-            run(["--strict"])
+        def test_strict_keep_lines(self):
+            run(["--strict", "--keep-lines"])
 
         def test_and(self):
             run(["--and"])  # src and dest built by comp

--- a/coconut/tests/main_test.py
+++ b/coconut/tests/main_test.py
@@ -1093,7 +1093,7 @@ if TEST_ALL:
         if not PYPY or PY2:
             def test_prelude(self):
                 with using_paths(prelude):
-                    comp_prelude()
+                    comp_prelude(expect_retcode=None)
                     if MYPY and PY38:
                         run_prelude()
 

--- a/coconut/tests/main_test.py
+++ b/coconut/tests/main_test.py
@@ -168,6 +168,7 @@ ignore_mypy_errs_with = (
     "tutorial.py",
     "unused 'type: ignore' comment",
     "site-packages/numpy",
+    ".py: error:"
 )
 
 ignore_atexit_errors_with = (

--- a/coconut/tests/src/cocotest/agnostic/main.coco
+++ b/coconut/tests/src/cocotest/agnostic/main.coco
@@ -35,7 +35,7 @@ def package_test(outer_MatchError) -> bool:
     assert MatchError() `isinstance` outer_MatchError, (MatchError, outer_MatchError)
     assert outer_MatchError() `isinstance` MatchError, (outer_MatchError, MatchError)
     assert_raises((raise)$(outer_MatchError), MatchError)
-    assert_raises((raise)$(MatchError), outer_MatchError)
+    assert_raises((raise)$(MatchError), outer_MatchError)  # type: ignore
     def raises_outer_MatchError(obj=None):
         raise outer_MatchError("raises_outer_MatchError")
     match raises_outer_MatchError -> None in 10:

--- a/coconut/tests/src/cocotest/agnostic/primary_1.coco
+++ b/coconut/tests/src/cocotest/agnostic/primary_1.coco
@@ -90,7 +90,7 @@ def primary_test_1() -> bool:
     \\assert data == 3
     \\def backslash_test():
         return (x) -> x
-    assert \(1) == 1 == backslash_test()(1)
+    assert \(1) == 1 == backslash_test()(1)  # NOQA
     assert True is (\(
             "hello"
         ) == "hello" == \(
@@ -100,7 +100,7 @@ def primary_test_1() -> bool:
                                    x,
                                    y):
         return x + y
-    assert multiline_backslash_test(1, 2) == 3
+    assert multiline_backslash_test(1, 2) == 3  # noqa
     \\ assert True
     class one_line_class: pass
     assert isinstance(one_line_class(), one_line_class)

--- a/coconut/tests/src/cocotest/agnostic/primary_2.coco
+++ b/coconut/tests/src/cocotest/agnostic/primary_2.coco
@@ -487,6 +487,7 @@ def primary_test_2() -> bool:
     match (x=) in (x=13, y=13):
         assert False
     assert x == 12
+    assert (x=1).__match_args__ == ('x',)  # type: ignore
 
     with process_map.multiple_sequential_calls():  # type: ignore
         assert map((+), range(3), range(4)$[:-1], strict=True) |> list == [0, 2, 4] == process_map((+), range(3), range(4)$[:-1], strict=True) |> list  # type: ignore

--- a/coconut/tests/src/cocotest/agnostic/primary_2.coco
+++ b/coconut/tests/src/cocotest/agnostic/primary_2.coco
@@ -466,6 +466,27 @@ def primary_test_2() -> bool:
 """ == '\n"2"\n'
     assert f"\{1}" == "\\1"
     assert f''' '{1}' ''' == " '1' "
+    tuple(x=) = (x=4)
+    assert x == 4
+    tuple(x=, y=) = (x=5, y=5)
+    assert x == 5 == y
+    data tuple(x=) = (x=6)
+    assert x == 6
+    class tuple(x=) = (x=7)
+    assert x == 7
+    data tuple(x, y=) = (x=8, y=8)
+    assert x == 8 == y
+    (x=, y=) = (x=9, y=9)
+    assert x == 9 == y
+    (x=x) = (x=10)
+    assert x == 10
+    (x=, y=y) = (x=11, y=11)
+    assert x == 11 == y
+    tuple(x=) = (x=12, y=12)
+    assert x == 12
+    match (x=) in (x=13, y=13):
+        assert False
+    assert x == 12
 
     with process_map.multiple_sequential_calls():  # type: ignore
         assert map((+), range(3), range(4)$[:-1], strict=True) |> list == [0, 2, 4] == process_map((+), range(3), range(4)$[:-1], strict=True) |> list  # type: ignore

--- a/coconut/tests/src/cocotest/agnostic/primary_2.coco
+++ b/coconut/tests/src/cocotest/agnostic/primary_2.coco
@@ -488,6 +488,9 @@ def primary_test_2() -> bool:
         assert False
     assert x == 12
     assert (x=1).__match_args__ == ('x',)  # type: ignore
+    assert reduce(function=(+), iterable=range(5), initial=-1) == 9  # type: ignore
+    assert takewhile(predicate=ident, iterable=[1, 2, 1, 0, 1]) |> list == [1, 2, 1]  # type: ignore
+    assert dropwhile(predicate=(not), iterable=range(5)) |> list == [1, 2, 3, 4]  # type: ignore
 
     with process_map.multiple_sequential_calls():  # type: ignore
         assert map((+), range(3), range(4)$[:-1], strict=True) |> list == [0, 2, 4] == process_map((+), range(3), range(4)$[:-1], strict=True) |> list  # type: ignore

--- a/coconut/tests/src/cocotest/agnostic/primary_2.coco
+++ b/coconut/tests/src/cocotest/agnostic/primary_2.coco
@@ -480,7 +480,7 @@ def primary_test_2() -> bool:
     assert x == 9 == y
     (x=x) = (x=10)
     assert x == 10
-    (x=, y=y) = (x=11, y=11)
+    (y=y, x=) = (x=11, y=11)
     assert x == 11 == y
     tuple(x=) = (x=12, y=12)
     assert x == 12

--- a/coconut/tests/src/cocotest/agnostic/suite.coco
+++ b/coconut/tests/src/cocotest/agnostic/suite.coco
@@ -637,7 +637,7 @@ def suite_test() -> bool:
     assert map(HasDefs().a_def, range(5)) |> list == range(1, 6) |> list
     assert HasDefs().a_def 1 == 2
     assert HasDefs().case_def 1 == 0 == HasDefs().case_def_ 1
-    assert HasDefs.__annotations__.keys() |> set == {"a_def"}, HasDefs.__annotations__
+    assert "a_def" in HasDefs.__annotations__.keys() |> set, HasDefs.__annotations__
     assert store.plus1 store.one == store.two
     assert ret_locals()["my_loc"] == 1
     assert ret_globals()["my_glob"] == 1

--- a/coconut/tests/src/cocotest/agnostic/suite.coco
+++ b/coconut/tests/src/cocotest/agnostic/suite.coco
@@ -637,7 +637,7 @@ def suite_test() -> bool:
     assert map(HasDefs().a_def, range(5)) |> list == range(1, 6) |> list
     assert HasDefs().a_def 1 == 2
     assert HasDefs().case_def 1 == 0 == HasDefs().case_def_ 1
-    assert "a_def" in HasDefs.__annotations__.keys() |> set, HasDefs.__annotations__
+    assert HasDefs.__annotations__.keys() |> set == {"a_def"}, HasDefs.__annotations__
     assert store.plus1 store.one == store.two
     assert ret_locals()["my_loc"] == 1
     assert ret_globals()["my_glob"] == 1

--- a/coconut/tests/src/cocotest/agnostic/suite.coco
+++ b/coconut/tests/src/cocotest/agnostic/suite.coco
@@ -178,7 +178,7 @@ def suite_test() -> bool:
     assert init_last([1,2,3]) == ([1,2], 3)
     assert last_two([1,2,3]) == (2, 3) == last_two_([1,2,3])
     assert expl_ident(5) == 5 == ident(5)
-    assert mod$ <| 5 <| 3 == 2 == (%)$ <| 5 <| 3
+    assert mod$ <| 5 <| 3 == 2 == (%)$ <| 5 <| 3  # type: ignore
     assert 5 |> dectest == 5
     try:
         raise ValueError()

--- a/coconut/tests/src/cocotest/agnostic/tutorial.coco
+++ b/coconut/tests/src/cocotest/agnostic/tutorial.coco
@@ -22,13 +22,15 @@ assert range(1, 5) |> product == 24
 first_five_words = .split() ..> .$[:5] ..> " ".join
 assert first_five_words("ab cd ef gh ij kl") == "ab cd ef gh ij"
 
-@recursive_iterator
+# TODO: recursive_iterator -> recursive_generator
+@recursive_iterator  # noqa
 def fib() = (1, 1) :: map((+), fib(), fib()$[1:])
 assert fib()$[:5] |> list == [1, 1, 2, 3, 5]
 
+# TODO: parallel_map -> process_map
 # can't use parallel_map here otherwise each process would have to rerun all
 #  the tutorial tests since we don't guard them behind __name__ == "__main__"
-assert range(100) |> concurrent_map$(.**2) |> list |> .$[-1] == 9801
+assert range(100) |> thread_map$(.**2) |> list |> .$[-1] == 9801
 
 def factorial(n, acc=1):
     match n:

--- a/coconut/tests/src/cocotest/target_2/py2_test.coco
+++ b/coconut/tests/src/cocotest/target_2/py2_test.coco
@@ -4,5 +4,5 @@ def py2_test() -> bool:
     assert py_map((+)$(2), range(5)) == [2, 3, 4, 5, 6]
     assert py_range(5) == [0, 1, 2, 3, 4]
     assert not isinstance(long(1), py_int)  # type: ignore
-    assert py_str(3) == b"3" == unicode(b"3")  # type: ignore
+    assert py_str(3) == b"3" == unicode(b"3")  # noqa  # type: ignore
     return True

--- a/coconut/tests/src/extras.coco
+++ b/coconut/tests/src/extras.coco
@@ -414,6 +414,16 @@ import abc
     except CoconutStyleError as err:
         assert str(err) == """found unused import 'abc' (add '# NOQA' to suppress) (remove --strict to downgrade to a warning) (line 1)
   import abc"""
+    try:
+        parse("""
+1
+2 + x
+3
+        """.strip())
+    except CoconutStyleError as err:
+        assert str(err) == """found undefined name 'x' (add '# NOQA' to suppress) (remove --strict to downgrade to a warning) (line 2)
+  2 + x
+      ^"""
     assert_raises(-> parse("""
 class A(object):
     1

--- a/coconut/tests/src/extras.coco
+++ b/coconut/tests/src/extras.coco
@@ -612,6 +612,15 @@ def test_kernel() -> bool:
     assert captured_msg_content is None
     assert captured_msg_type["content"]["data"]["text/plain"] == "'()'"
 
+    assert k.do_execute("""[
+    "hey",
+    # "there", # dont want this value now
+    "is comment"
+]""", False, True, {}, True) |> unwrap_future$(loop) |> .["status"] == "ok"
+    captured_msg_type, captured_msg_content = fake_session.captured_messages[-1]
+    assert captured_msg_content is None
+    assert captured_msg_type["content"]["data"]["text/plain"] == "['hey', 'is comment']"
+
     return True
 
 

--- a/coconut/tests/src/extras.coco
+++ b/coconut/tests/src/extras.coco
@@ -7,8 +7,7 @@ os.environ["COCONUT_USE_COLOR"] = "False"
 from coconut.__coconut__ import consume as coc_consume
 from coconut.constants import (
     IPY,
-    PY2,
-    PY34,
+    NUMPY,
     PY35,
     PY36,
     PY39,
@@ -762,13 +761,13 @@ def test_xarray() -> bool:
 
 
 def test_extras() -> bool:
-    if not PYPY and (PY2 or PY34):
+    if NUMPY:
         assert test_numpy() is True
     print(".", end="")
-    if not PYPY and PY36:
+    if NUMPY and PY36:
         assert test_pandas() is True  # .
     print(".", end="")
-    if not PYPY and PY39:
+    if NUMPY and PY39:
         assert test_xarray() is True # ..
     print(".")  # newline bc we print stuff after this
     assert test_setup_none() is True  # ...


### PR DESCRIPTION
See Coconut's [documentation](http://coconut.readthedocs.io/en/develop/DOCS.html) for more information on all of the features listed below.

Bugfixes:
* #851, #852: Fixed comments inside of parentheses in the Jupyter kernel.

Language features:
* #846: `reduce`, `takewhile`, and `dropwhile` now support keyword arguments.
* #848: Class and data patterns now support keyword argument name elision.
* #847: New pattern-matching syntax for matching anonymous named tuples.

Compiler features:
* #843: Added compiler warnings for (some cases of) undefined variables.