### PR TITLE
Fixed ADT example in DOCS.md

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1330,9 +1330,9 @@ data Leaf(n) from Tree
 data Node(l, r) from Tree
 
 case def depth:
-    case(Tree()) = 0
-    case(Tree(n)) = 1
-    case(Tree(l, r)) = 1 + max(depth(l), depth(r))
+    case(Empty()) = 0
+    case(Leaf(n)) = 1
+    case(Node(l, r)) = 1 + max(depth(l), depth(r))
 
 Empty() |> depth |> print
 Leaf(5) |> depth |> print


### PR DESCRIPTION
The example as it is runs and compiles, but the functionality is wrong.
With the original formulation, the output is:
```
0
0
0
```

While it should've been:
```
0
1
3
```

This is because the cases in the `depth` function are using the constructor of `Tree` instead of the ones defined as `data`.
Changing the pattern matching to the correct constructors fixes the behaviour.
