### PR TITLE
Update DOCS.md: change prompt_end to the right xonsh character

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -505,9 +505,9 @@ Coconut integrates with [`xonsh`](https://xon.sh/) to allow the use of Coconut c
 
 For an example of using Coconut from `xonsh`:
 ```
-user@computer ~ $ xontrib load coconut
-user@computer ~ $ cd ./files
-user@computer ~ $ $(ls -la) |> .splitlines() |> len
+user@computer ~ @ xontrib load coconut
+user@computer ~ @ cd ./files
+user@computer ~ @ $(ls -la) |> .splitlines() |> len
 30
 ```
 


### PR DESCRIPTION
Hey! In [xonsh project](https://xon.sh/) we want to avoid misunderstandings between POSIX and Python shells. So it's the guideline to use xonsh default prompt_end `@` instead of `$`. Thanks!