### PR TITLE
chore: Add linguist override for Coconut syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 # Treat Coconut and Python template files as Python
 *.coco          diff=python
 *.py_template   diff=python
+*.coco linguist-language=Python


### PR DESCRIPTION
Fixes #335. Appended a rule to .gitattributes to force GitHub Linguist to treat `*.coco` files as Python.