### PR TITLE
Fix xonsh xontrib in .xsh scripts and execx

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -518,7 +518,7 @@ user@computer ~ @ $(ls -la) |> .splitlines() |> len
 
 Compilation always uses the same parameters as in the [Coconut Jupyter kernel](#kernel).
 
-Note that the way that Coconut integrates with `xonsh`, `@(<code>)` syntax and the `execx` command will only work with Python code, not Coconut code. Additionally, Coconut will only compile individual commands—Coconut will not touch the `.xonshrc` or any other `.xsh` files.
+Note that the way that Coconut integrates with `xonsh`, `@(<code>)` syntax and `evalx` will only work with Python code, not Coconut code. Coconut compilation is enabled for interactive commands, `.xsh` scripts, and `execx`, but not for `eval`-mode contexts.
 
 
 ## Operators

--- a/coconut/compiler/grammar.py
+++ b/coconut/compiler/grammar.py
@@ -2780,7 +2780,7 @@ class Grammar(object):
             )
         )
         unsafe_xonsh_parser, _impl_call_ref = disable_inside(
-            single_input - end_marker,
+            file_input - end_marker,
             unsafe_impl_call_ref,
         )
         impl_call_ref <<= _impl_call_ref

--- a/coconut/constants.py
+++ b/coconut/constants.py
@@ -1359,7 +1359,7 @@ all_keywords = keyword_vars + const_vars + reserved_vars
 
 conda_build_env_var = "CONDA_BUILD"
 
-enabled_xonsh_modes = ("single",)
+enabled_xonsh_modes = ("single", "exec")
 
 # 1 is safe, 2 seems to work okay, and 3 breaks stuff like '"""\n(\n)\n"""'
 num_assemble_logical_lines_tries = 1

--- a/coconut/root.py
+++ b/coconut/root.py
@@ -26,7 +26,7 @@ import sys as _coconut_sys
 VERSION = "3.2.0"
 VERSION_NAME = None
 # False for release, int >= 1 for develop
-DEVELOP = 16
+DEVELOP = 17
 ALPHA = False  # for pre releases rather than post releases
 
 assert DEVELOP is False or DEVELOP >= 1, "DEVELOP must be False or an int >= 1"

--- a/coconut/tests/main_test.py
+++ b/coconut/tests/main_test.py
@@ -978,7 +978,7 @@ class TestShell(unittest.TestCase):
                     pexpect(p, "abc")
                     pexpect(p, "2")
                 p.sendline('execx("10 |> print")')
-                pexpect(p, ["subprocess mode", "IndexError"])
+                pexpect(p, "10")
             p.sendline("xontrib unload coconut")
             pexpect(p, "$")
             if (not PYPY or PY39) and PY36:


### PR DESCRIPTION
## Summary

Resolves [xonsh/xonsh#5823](https://github.com/xonsh/xonsh/issues/5823) and refs #883.

The xonsh xontrib only preprocessed code in xonsh's `single` parse mode (interactive REPL). When a `.xsh` script or `execx(...)` runs, xonsh compiles with `mode="exec"`, so Coconut left `|>` alone and xonsh's parser then split it into `|` and `>`, eventually crashing in `run_subproc` with `IndexError: list index out of range` (`xonsh/procs/specs.py:707`).

```xsh
#!/usr/bin/env xonsh
$(ls) |> .splitlines() |> len |> print   # IndexError before this PR
```

## Changes

- `coconut/constants.py` — add `"exec"` to `enabled_xonsh_modes` so the xontrib hooks run for scripts and `execx`. xonsh already caches compiled `.xsh` bytecode via `run_script_with_cache`, and Coconut already memoizes `parse_xonsh` per process, so the original `.xonshrc` slowness from #724 stays mitigated.
- `coconut/compiler/grammar.py` — `unsafe_xonsh_parser` was built from `single_input`, which accepts only one statement, so multi-statement scripts failed with `CoconutParseError: Expected end of text` once `exec` was enabled. Switch to `file_input` (superset of `single_input`); single-statement input still parses correctly.
- `coconut/tests/main_test.py` — `execx("10 |> print")` previously asserted failure (`subprocess mode` / `IndexError`); it now succeeds and prints `10`.
- `DOCS.md` — note that `.xsh` scripts and `execx` now work; only `@(<code>)` and `evalx` remain Python-only.
- `coconut/root.py` — bump `DEVELOP`.

## Test plan

- [x] Original issue repro: `$(ls) |> .splitlines() |> len |> print` from a `.xsh` script — works.
- [x] Multi-statement script with `1 |> print`, `"hello" |> .upper() |> print`, `[1,2,3] |> sum |> print` — all run.
- [x] `execx("10 |> print")` — prints `10`.
- [x] Plain Python `.xsh` scripts and subprocess-mode commands (`echo`, `ls`) — no regression.
- [x] Existing interactive REPL behavior (`!(ls -la) |> bool`, `'1; 2' |> print`, `len("""1\n3\n5""")`) — unchanged.
- [x] Existing API assertions for `parse(..., "xonsh")` in `extras.coco` (lines 326–327) — still pass.